### PR TITLE
remove insights.chrome ref

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -116,7 +116,7 @@ export const activeTechnologies = [
         apps: {
             'automation analytics': '/automation-analytics',
             'automation hub': '/automation-hub',
-            ...window.insights.chrome.isBeta() && { 'automation service catalog': '/catalog' }
+            ...window.location.pathname.indexOf('/beta') !== 0 && { 'automation service catalog': '/catalog' }
         },
         marketing: true,
         marketingImage: ansibleMarketing,


### PR DESCRIPTION
There is no `window.insights` on the 404 page. Remove this in place of just checking the url.