### PR TITLE
Update fce dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6314,45 +6314,26 @@
       "integrity": "sha512-vhDBtwkp1PTAqXDjAsUPRf/ewBh2Asong8MPr9ZGeXAeOULW8creW7GJx+JZX9eaEJMA3ESMeZ6wZ5j/yyWMGQ=="
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.4.9.tgz",
-      "integrity": "sha512-Vs1cNv040Kga2wifglTVUAgvXbtLOa6k+JSNT09764k3omR3kXtByR5Sb/zHhk8QW+K16ZPlh4IAY8UEwXlPVw==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.4.13.tgz",
+      "integrity": "sha512-EHLD/aKa3n9wnUAP6O2vuRUD/CH40tt4AGP+2DXPnUJlYzEu+6RASXAonxoiTQ6AUJsbNFZ0xv35vDEkYD5mng==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "sanitize-html": "^1.25.0"
       }
     },
     "@redhat-cloud-services/frontend-components-notifications": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-2.2.2.tgz",
-      "integrity": "sha512-CTOJNgZLU18HUACc1GqD+yR4Ml4lcHEBSOLfFbVU9LVzymaXEpv62gW4CKUFUWpCO4LpBowZMtL4Vh8bda5dTg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-2.2.3.tgz",
+      "integrity": "sha512-ERqumLKIYsZ96WINj8mK1gnaXJsgHCOItX8xp6/MS5C8BQ+h8U/R3KO54HR0XqBZzI8/zFXTBUDmRPlb6gE4TA==",
       "requires": {
-        "@redhat-cloud-services/frontend-components-utilities": "2.1.0-beta"
-      },
-      "dependencies": {
-        "@redhat-cloud-services/frontend-components-utilities": {
-          "version": "2.1.0-beta",
-          "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.1.0-beta.tgz",
-          "integrity": "sha512-4qF+ElZaBRXnWtdpIY/VF2TA4sGTkHbHUQVy3gV6Uu1h2YHpuxhKuiJhB/Gq/BgPmkU7yVV2Dpm//iCe6ObOUg==",
-          "requires": {
-            "@sentry/browser": "^5.4.0",
-            "awesome-debounce-promise": "^2.1.0",
-            "axios": "^0.19.0",
-            "commander": ">=2.20.0",
-            "react-content-loader": ">=3.4.1"
-          }
-        },
-        "commander": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
-          "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA=="
-        }
+        "@redhat-cloud-services/frontend-components-utilities": "*"
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.2.4.tgz",
-      "integrity": "sha512-Fhc4G8cIQVgwfA7AJCv6ri3tGvmTpjcQbRGelWiCdlkcxn/c4oC4hMnvKdAPr8HFPzug1D9vEP9Ojw/kvhZ7UA==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.2.5.tgz",
+      "integrity": "sha512-XvOvnTALiJGHyVftCjTFWofLjeMnO7gb0S3c949QZo8I+07vd7AsEvrps24RoBnO6S6qlAjOhPPxfSvt9Ie6YA==",
       "requires": {
         "@sentry/browser": "^5.4.0",
         "awesome-debounce-promise": "^2.1.0",
@@ -6369,59 +6350,59 @@
       }
     },
     "@sentry/browser": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.24.2.tgz",
-      "integrity": "sha512-P/uZC/VrLRpU7MVEJnlZK5+AkEmuHu+mns5gC91Z4gjn7GamjR/CaXVedHGw/15ZrsQiAiwoWwuxpv4Ypd/+SA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.25.0.tgz",
+      "integrity": "sha512-QDVUbUuTu58xCdId0eUO4YzpvrPdoUw1ryVy/Yep9Es/HD0fiSyO1Js0eQVkV/EdXtyo2pomc1Bpy7dbn2EJ2w==",
       "requires": {
-        "@sentry/core": "5.24.2",
-        "@sentry/types": "5.24.2",
-        "@sentry/utils": "5.24.2",
+        "@sentry/core": "5.25.0",
+        "@sentry/types": "5.25.0",
+        "@sentry/utils": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.24.2.tgz",
-      "integrity": "sha512-nuAwCGU1l9hgMinl5P/8nIQGRXDP2FI9cJnq5h1qiP/XIOvJkJz2yzBR6nTyqr4vBth0tvxQJbIpDNGd7vHJLg==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.25.0.tgz",
+      "integrity": "sha512-hY6Zmo7t/RV+oZuvXHP6nyAj/QnZr2jW0e7EbL5YKMV8q0vlnjcE0LgqFXme726OJemoLk67z+sQOJic/Ztehg==",
       "requires": {
-        "@sentry/hub": "5.24.2",
-        "@sentry/minimal": "5.24.2",
-        "@sentry/types": "5.24.2",
-        "@sentry/utils": "5.24.2",
+        "@sentry/hub": "5.25.0",
+        "@sentry/minimal": "5.25.0",
+        "@sentry/types": "5.25.0",
+        "@sentry/utils": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.24.2.tgz",
-      "integrity": "sha512-xmO1Ivvpb5Qr9WgekinuZZlpl9Iw7iPETUe84HQOhUrXf+2gKO+LaUYMMsYSVDwXQEmR6/tTMyOtS6iavldC6w==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.25.0.tgz",
+      "integrity": "sha512-kOlOiJV8wMX50lYpzMlOXBoH7MNG0Ho4RTusdZnXZBaASq5/ljngDJkLr6uylNjceZQP21wzipCQajsJMYB7EQ==",
       "requires": {
-        "@sentry/types": "5.24.2",
-        "@sentry/utils": "5.24.2",
+        "@sentry/types": "5.25.0",
+        "@sentry/utils": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.24.2.tgz",
-      "integrity": "sha512-biFpux5bI3R8xiD/Zzvrk1kRE6bqPtfWXmZYAHRtaUMCAibprTKSY9Ta8QYHynOAEoJ5Akedy6HUsEkK5DoZfA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.25.0.tgz",
+      "integrity": "sha512-9JFKuW7U+1vPO86k3+XRtJyooiVZsVOsFFO4GulBzepi3a0ckNyPgyjUY1saLH+cEHx18hu8fGgajvI8ANUF2g==",
       "requires": {
-        "@sentry/hub": "5.24.2",
-        "@sentry/types": "5.24.2",
+        "@sentry/hub": "5.25.0",
+        "@sentry/types": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.24.2.tgz",
-      "integrity": "sha512-HcOK00R0tQG5vzrIrqQ0jC28+z76jWSgQCzXiessJ5SH/9uc6NzdO7sR7K8vqMP2+nweCHckFohC8G0T1DLzuQ=="
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.25.0.tgz",
+      "integrity": "sha512-8M4PREbcar+15wrtEqcwfcU33SS+2wBSIOd/NrJPXJPTYxi49VypCN1mZBDyWkaK+I+AuQwI3XlRPCfsId3D1A=="
     },
     "@sentry/utils": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.24.2.tgz",
-      "integrity": "sha512-oPGde4tNEDHKk0Cg9q2p0qX649jLDUOwzJXHKpd0X65w3A6eJByDevMr8CSzKV9sesjrUpxqAv6f9WWlz185tA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.25.0.tgz",
+      "integrity": "sha512-Hz5spdIkMSRH5NR1YFOp5qbsY5Ud2lKhEQWlqxcVThMG5YNUc10aYv5ijL19v0YkrC2rqPjCRm7GrVtzOc7bXQ==",
       "requires": {
-        "@sentry/types": "5.24.2",
+        "@sentry/types": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
@@ -6923,7 +6904,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -8496,7 +8476,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -16291,7 +16270,6 @@
       "version": "7.0.35",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
       "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
-      "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -16302,7 +16280,6 @@
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -17921,34 +17898,6 @@
         "postcss": "^7.0.27"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
         "dom-serializer": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.1.0.tgz",
@@ -17965,21 +17914,21 @@
           "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
         },
         "domhandler": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.2.0.tgz",
-          "integrity": "sha512-FnT5pxGpykNI10uuwyqae65Ysw7XBQJKDjDjlHgE/rsNtjr1FyGNVNQCVlM5hwcq9wkyWSqB+L5Z+Qa4khwLuA==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
           "requires": {
             "domelementtype": "^2.0.1"
           }
         },
         "domutils": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.1.tgz",
-          "integrity": "sha512-AA5r2GD1Dljhxc+k4zD2HYQaDkDPBhTqmqF55wLNlxfhFQlqaYME8Jhmo2nKNBb+CNfPXE8SAjtF6SsZ0cza/w==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz",
+          "integrity": "sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==",
           "requires": {
             "dom-serializer": "^1.0.1",
             "domelementtype": "^2.0.1",
-            "domhandler": "^3.2.0"
+            "domhandler": "^3.3.0"
           }
         },
         "entities": {
@@ -17996,24 +17945,6 @@
             "domhandler": "^3.0.0",
             "domutils": "^2.0.0",
             "entities": "^2.0.0"
-          }
-        },
-        "postcss": {
-          "version": "7.0.35",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-          "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -19977,7 +19908,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
     "@patternfly/patternfly": "^4.10.29",
     "@patternfly/react-core": "^4.18.5",
     "@patternfly/react-icons": "^4.3.3",
-    "@redhat-cloud-services/frontend-components": "^2.4.9",
-    "@redhat-cloud-services/frontend-components-notifications": "^2.2.2",
-    "@redhat-cloud-services/frontend-components-utilities": "^2.2.4",
+    "@redhat-cloud-services/frontend-components": "^2.4.13",
+    "@redhat-cloud-services/frontend-components-notifications": "^2.2.3",
+    "@redhat-cloud-services/frontend-components-utilities": "^2.2.5",
     "classnames": "^2.2.6",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
This will remove the redux production warning from the landing page for good!

Confirms that the FCE notifications updates resolve: https://issues.redhat.com/browse/RHCLOUD-6078 after updating packages.