### PR TITLE
add an alert for internal page

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -240,5 +240,12 @@ export const activeTechnologies = [
         url: 'user-preferences',
         disabled: true,
         emptyAlertTitle: 'You need an account number to access this page'
+    },
+    {
+        id: 'internal',
+        entitlement: 'internal',
+        url: 'internal',
+        disabled: true,
+        emptyAlertTitle: 'You do not have access to this page'
     }
 ];


### PR DESCRIPTION
If a user does not have access to /internal, they'll get kicked back out and let's throw an error message. As mentioned in the chrome update, this is going to happen to everyone until the internal entitlement gets added to the entitlements-api