### PR TITLE
 Landing page update 3

### DIFF
--- a/src/layout/landingPage/SecondPanel.js
+++ b/src/layout/landingPage/SecondPanel.js
@@ -5,7 +5,7 @@ import SecondPanelTile from './SecondPanelTile';
 const SecondPanel = () => {
   return (
     <Flex className="second-level">
-      <Flex className="section col1" hasGutter>
+      <Flex className="section" hasGutter>
         <Flex className="subsection">
           <FlexItem>
             <Text component="h1">Application Services Recommendations</Text>
@@ -27,7 +27,7 @@ const SecondPanel = () => {
           </FlexItem>
         </Flex>
       </Flex>
-      <Flex className="section col2">
+      <Flex className="section">
         <Flex className="subsection">
           <FlexItem>
             <Text component="h1">Platform insights</Text>
@@ -48,7 +48,7 @@ const SecondPanel = () => {
           </FlexItem>
         </Flex>
       </Flex>
-      <Flex className="section col3">
+      <Flex className="section">
         <Flex className="subsection">
           <FlexItem>
             <Text component="h1">&nbsp;</Text>

--- a/src/layout/landingPage/SecondPanelTile.js
+++ b/src/layout/landingPage/SecondPanelTile.js
@@ -22,7 +22,7 @@ const SecondPanelTile = ({ title, bodyText, buttonLabel }) => {
 
 SecondPanelTile.defaultProps = {
   tileItems: [],
-  bodyText: 'Lorem ipsum dolor sit amet',
+  bodyText: 'Lorem ipsum dolor sit amet, conse ctetur adipiscing elit',
   title: '',
   buttonLabel: 'Action',
 };

--- a/src/layout/landingPage/styles/Panels.scss
+++ b/src/layout/landingPage/styles/Panels.scss
@@ -38,7 +38,24 @@
       }
     }
   }
-  @media screen and (max-width: 1100px) {
+
+  @media screen and (min-width: 1176px) and (max-width: 1450px) {
+    .first-level {
+      .section {
+        --pf-l-flex--spacer: 0;
+        .tile {
+          width: 238px;
+          flex-direction: column;
+          --pf-l-flex--spacer: var(--pf-global--spacer--md);
+          &:last-child {
+            --pf-l-flex--spacer: var(--pf-global--spacer--md);
+          }
+        }
+      }
+    }
+  }
+
+  @media screen and (max-width: 1175px) {
     .first-level {
       flex-direction: column;
       padding-right: var(--pf-global--spacer--lg);
@@ -76,12 +93,12 @@
     color: var(--pf-global--Color--100);
     padding: var(--pf-global--spacer--2xl) var(--pf-global--spacer--lg) 0 var(--pf-global--spacer--lg);
     flex-direction: row;
-    .pf-l-flex.section.col1{width: 370px;}
-    .pf-l-flex.section.col2{width: 320px;}
-    .pf-l-flex.section.col3{width: 320px;}
     .section {
       flex-direction: column;
       --pf-l-flex--spacer: var(--pf-global--spacer--2xl);
+      &:nth-of-type(1){width: 370px;}
+      &:nth-of-type(2){width: 320px;}
+      &:nth-of-type(3){width: 320px;}
       &:last-child {
         --pf-l-flex--spacer: 0; 
       }
@@ -107,8 +124,9 @@
             margin-bottom: var(--pf-global--spacer--md);
           }
           .tile {
-            width: 100%;
+            flex-wrap: nowrap;
             margin-bottom: var(--pf-global--spacer--md);
+            width: 100%;
             &:last-child {
               margin-bottom: 0;
             }
@@ -122,32 +140,36 @@
     }
   }
 
-  @media screen and (max-width: 1100px) {
+  @media screen and (min-width: 1176px) and (max-width: 1450px) {
+    .second-level {
+      .section {
+        &:nth-of-type(3) { 
+          margin-left: 418px;
+          .subsection > div > h1 {
+            display: none;
+          }
+        }
+      }
+    }
+  }
+
+  @media screen and (max-width: 1175px) {
     .second-level {
       flex-direction: column;
       padding-right: var(--pf-global--spacer--lg);
       .pf-l-flex.section {
         flex-direction: column;
       }
-      .pf-l-flex.section.col1,
-      .pf-l-flex.section.col2,
-      .pf-l-flex.section.col3 {
-        width: 100%;
+      .section {
+        &:nth-of-type(1){width: 100%;}
+        &:nth-of-type(2){width: 100%;}
+        &:nth-of-type(3){width: 100%;}
       }
       .pf-l-flex.section.col3 {
         .subsection > div > h1 {
           display: none;
         }
       }
-    }
-  }
-
-  @media screen and (min-width: 1101px) and (max-width: 1450px) {
-    .second-level .pf-l-flex.section.col3 .subsection > div > h1 {
-      display: none;
-    }
-    .second-level .pf-l-flex.section.col3 {
-      width: 370px;
     }
   }
 


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-11763
https://docs.google.com/document/d/1v7GWs-bD6Oret9kaZs06yWsM_4qwT0ZtkLiKystjeAE/

- Adjusts responsiveness for first (Estate) row in two column layout
- Move 'Security' under 'Financial' in two column layout

<img width="1174" alt="Screen Shot 2021-01-25 at 4 08 59 PM" src="https://user-images.githubusercontent.com/1287144/105766450-c2b5f500-5f27-11eb-857f-48bfcff69f0b.png">
<img width="916" alt="Screen Shot 2021-01-25 at 4 09 32 PM" src="https://user-images.githubusercontent.com/1287144/105766452-c34e8b80-5f27-11eb-9c14-37855b8b67ef.png">

