### PR TITLE
Use chrome 2 container

### DIFF
--- a/proxy-config/local-frontend.js
+++ b/proxy-config/local-frontend.js
@@ -1,23 +1,21 @@
-/*global module, process*/
-
 module.exports = {
-    routes: {
-        '/apps/landing/': { host: 'https://localhost:8002' },
-        '/apps/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/rhev/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/insights/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/openshift/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/cost-management/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/api/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/migrations/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/ansible/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/subscriptions/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/': { host: 'https://localhost:8002' },
-        '/maintenance': { host: 'https://localhost:8002' },
-        '/404': { host: 'https://localhost:8002' },
-        '/beta/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/beta/apps/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/config/': { host: 'PORTAL_BACKEND_MARKER' },
-        '/beta/config/': { host: 'PORTAL_BACKEND_MARKER' },
-    }
+  routes: {
+    '/apps/landing/': { host: 'https://localhost:8002' },
+    '/apps/': { host: 'PORTAL_BACKEND_MARKER' },
+    '/rhev/': { host: 'PORTAL_BACKEND_MARKER' },
+    '/insights/': { host: 'PORTAL_BACKEND_MARKER' },
+    '/openshift/': { host: 'PORTAL_BACKEND_MARKER' },
+    '/cost-management/': { host: 'PORTAL_BACKEND_MARKER' },
+    '/api/': { host: 'PORTAL_BACKEND_MARKER' },
+    '/migrations/': { host: 'PORTAL_BACKEND_MARKER' },
+    '/ansible/': { host: 'PORTAL_BACKEND_MARKER' },
+    '/subscriptions/': { host: 'PORTAL_BACKEND_MARKER' },
+    '/': { host: 'https://localhost:8002' },
+    '/maintenance': { host: 'https://localhost:8002' },
+    '/404': { host: 'https://localhost:8002' },
+    '/beta/silent-check-sso.html': { host: 'PORTAL_BACKEND_MARKER' },
+    '/beta/config': { host: 'PORTAL_BACKEND_MARKER' },
+    '/beta/': { host: 'https://localhost:8002' },
+    '/beta/apps/': { host: 'https://localhost:8002' },
+  },
 };

--- a/src/App.js
+++ b/src/App.js
@@ -44,7 +44,7 @@ const App = ({ loadTechnologies }) => {
     window.insights.chrome.auth
       .getUser()
       .then((user) => user && setIsOrgAdmin(user.identity.user.is_org_admin));
-  });
+  }, []);
 
   return (
     <PermissionContext.Provider value={{ isOrgAdmin }}>

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
   </head>
 
   <body class="ins-c-landing-page">
-    <esi:include src="/@@env/chrome/snippets/landing-nav.html" />
+    <esi:include src="/@@env/chrome/snippets/body.html" />
   </body>
 
 </html>


### PR DESCRIPTION
Added necessary changes to display nav on the landing page.
Pushing to QA is already disabled in the Travis release.

### Changes
- landing page now uses the body.html snippet, show/hide logic is handled by chrome 2

merge with: https://github.com/RedHatInsights/insights-chrome/pull/1181