### PR TITLE
Chrome 2 styling follow-up

### DIFF
--- a/src/layout/landingPage/styles/Panels.scss
+++ b/src/layout/landingPage/styles/Panels.scss
@@ -274,10 +274,11 @@
         .section {
           align-self:stretch;
           flex-direction: row;
+          margin-right: 0;
           .tile {
-            flex-basis: auto;
-            flex-basis: 50%;
+            flex-basis: 48%;
             align-self:stretch;
+            margin-bottom: var(--pf-global--spacer--md);
             .section-title { 
               padding-top: var(--pf-global--spacer--md);
               padding-bottom: 0;


### PR DESCRIPTION
Follow-up to: https://github.com/RedHatInsights/landing-page-frontend/pull/189

Fixes broken responsive layout (1200px to  1449px )of the bottom section

Old:

<img width="1073" alt="Screen Shot 2021-02-10 at 2 55 08 PM" src="https://user-images.githubusercontent.com/1287144/107564170-08bdba80-6bb0-11eb-99a7-f4a9f4b63170.png">

New
<img width="1088" alt="Screen Shot 2021-02-10 at 2 48 23 PM" src="https://user-images.githubusercontent.com/1287144/107563776-79180c00-6baf-11eb-8574-151f38b0d414.png">
