### PR TITLE
hide labels for summit recordings

### DIFF
--- a/src/layout/landingPage/FirstPanelTile.js
+++ b/src/layout/landingPage/FirstPanelTile.js
@@ -40,7 +40,7 @@ const FirstPanelTile = ({ count, section, title, labelText, variant }) => {
       <FlexItem className="name">
         <Text component="p">{title}</Text>
       </FlexItem>
-      <FlexItem className="label">
+      <FlexItem className="label ins-m-hidden">
         <Label icon={icon} variant="outline" color={color}>
           {labelText}
         </Label>

--- a/src/layout/landingPage/styles/Panels.scss
+++ b/src/layout/landingPage/styles/Panels.scss
@@ -53,6 +53,9 @@
             --pf-c-label--FontSize: var(--pf-global--FontSize--xs);
           }
         }
+        .ins-m-hidden {
+          display: none !important;
+        }
       }
     }
   }


### PR DESCRIPTION
These will come back post summit, so just hiding it with css for now.