### PR TITLE
Fix landing page estate section layout.

### DIFF
--- a/src/layout/landingPage/FirstPanel.js
+++ b/src/layout/landingPage/FirstPanel.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex } from '@patternfly/react-core';
+import { DescriptionList } from '@patternfly/react-core';
 import { shallowEqual, useSelector } from 'react-redux';
 
 import estateRenderer from '../../components/app-content-renderer/estate-renderer';
@@ -12,9 +12,10 @@ const FirstPanel = () => {
     shallowEqual
   );
   return (
-    <Flex className="first-level">
-      <Flex className="level-wrapper">{estateRenderer(estate)}</Flex>
-    </Flex>
+    // To customize breakpoints etc use https://www.patternfly.org/v4/components/description-list#examples
+    <DescriptionList isAutoFit className="first-level pf-u-p-lg">
+      {estateRenderer(estate)}
+    </DescriptionList>
   );
 };
 

--- a/src/layout/landingPage/FirstPanel.js
+++ b/src/layout/landingPage/FirstPanel.js
@@ -8,7 +8,7 @@ import './styles/Panels.scss';
 
 const FirstPanel = () => {
   const estate = useSelector(
-    ({ contentStore: { estate } }) => estate,
+    ({ contentStore: { estate } }) => estate.slice(0, 6),
     shallowEqual
   );
   return (

--- a/src/layout/landingPage/FirstPanelTile.js
+++ b/src/layout/landingPage/FirstPanelTile.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import {
   DescriptionListDescription,
   DescriptionListGroup,
@@ -10,19 +11,23 @@ import {
 
 const FirstPanelTile = ({ count, section, title }) => {
   return (
-    <DescriptionListGroup>
-      <DescriptionListDescription>
+    <DescriptionListGroup className="estate-group">
+      <DescriptionListDescription
+        className={classnames('estate-section', {
+          'is-empty': section.length === 0,
+        })}
+      >
         <Text component="p">
           {section}&nbsp;
           {/** empty line char is required to keep proper horizontal alignment. Empty "p" tag does not have height */}
         </Text>
       </DescriptionListDescription>
-      <DescriptionListTerm>
-        <Title headingLevel="h6" size="2xl">
+      <DescriptionListTerm className="estate-count">
+        <Title headingLevel="h5" size="3xl">
           {count}
         </Title>
       </DescriptionListTerm>
-      <DescriptionListDescription>
+      <DescriptionListDescription className="estate-title">
         <Text component="p">{title}</Text>
       </DescriptionListDescription>
     </DescriptionListGroup>
@@ -30,8 +35,7 @@ const FirstPanelTile = ({ count, section, title }) => {
 };
 
 FirstPanelTile.defaultProps = {
-  labelText: ' OK',
-  variant: 'success',
+  section: '',
 };
 
 FirstPanelTile.propTypes = {

--- a/src/layout/landingPage/FirstPanelTile.js
+++ b/src/layout/landingPage/FirstPanelTile.js
@@ -1,51 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, FlexItem, Label, Text, Title } from '@patternfly/react-core'; //
-import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
-import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import {
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Text,
+  Title,
+} from '@patternfly/react-core';
 
-const FirstPanelTile = ({ count, section, title, labelText, variant }) => {
-  let color;
-  let icon;
-
-  switch (variant) {
-    case 'success':
-      color = 'green';
-      icon = <CheckCircleIcon />;
-      break;
-    case 'warning':
-      color = 'orange';
-      icon = <ExclamationTriangleIcon />;
-      break;
-    case 'danger':
-      color = 'red';
-      icon = <ExclamationCircleIcon />;
-      break;
-  }
-
+const FirstPanelTile = ({ count, section, title }) => {
   return (
-    <Flex className="tile">
-      <FlexItem>
-        <Text component="p" className="title">
-          {section}
+    <DescriptionListGroup>
+      <DescriptionListDescription>
+        <Text component="p">
+          {section}&nbsp;
+          {/** empty line char is required to keep proper horizontal alignment. Empty "p" tag does not have height */}
         </Text>
-      </FlexItem>
-      <FlexItem className="break" /> {/*break for mobile layout*/}
-      <FlexItem className="count">
-        <Title headingLevel="h6" className="count">
+      </DescriptionListDescription>
+      <DescriptionListTerm>
+        <Title headingLevel="h6" size="2xl">
           {count}
         </Title>
-      </FlexItem>
-      <FlexItem className="name">
+      </DescriptionListTerm>
+      <DescriptionListDescription>
         <Text component="p">{title}</Text>
-      </FlexItem>
-      <FlexItem className="label ins-m-hidden">
-        <Label icon={icon} variant="outline" color={color}>
-          {labelText}
-        </Label>
-      </FlexItem>
-    </Flex>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
   );
 };
 
@@ -58,8 +38,6 @@ FirstPanelTile.propTypes = {
   title: PropTypes.string.isRequired,
   count: PropTypes.string.isRequired,
   section: PropTypes.string,
-  labelText: PropTypes.string,
-  variant: PropTypes.oneOf(['success', 'danger', 'warning']),
 };
 
 export default FirstPanelTile;

--- a/src/layout/landingPage/styles/Panels.scss
+++ b/src/layout/landingPage/styles/Panels.scss
@@ -27,6 +27,42 @@
   .first-level {
     background-color: var(--pf-global--primary-color--200);
     color: var(--pf-global--Color--light-100);
+    /**
+    * to keep the 6 columns on line
+    */
+    grid-template-columns: repeat(auto-fill, calc(100% / 6 - var(--pf-c-description-list--ColumnGap)));
+    @media (max-width: 992px) {
+      /**
+      * Have 3 columns
+      */
+      grid-template-columns: repeat(auto-fill, calc(100% / 3 - var(--pf-c-description-list--ColumnGap)));
+    }
+    @media (max-width: 576px) {
+      /**
+      * Only one column
+      */
+      grid-template-columns: repeat(auto-fill, calc(100% - var(--pf-c-description-list--ColumnGap)));
+      row-gap: 0;
+      .estate-group {
+        display: flex;
+        flex-wrap: wrap;
+        .estate-section {
+          padding-top: var(--pf-global--spacer--md);
+          padding-bottom: var(--pf-global--spacer--md);
+          &.is-empty {
+            display: none;
+          }
+          font-size: var(--pf-global--FontSize--xl) !important;
+          width: 100%;
+        }
+        .estate-count {
+          font-size: var(--pf-global--FontSize--xl) !important;
+        }
+        .estate-title {
+          font-size: var(--pf-global--FontSize--sm) !important;
+        }
+      }
+    }
   }
 
 

--- a/src/layout/landingPage/styles/Panels.scss
+++ b/src/layout/landingPage/styles/Panels.scss
@@ -27,89 +27,9 @@
   .first-level {
     background-color: var(--pf-global--primary-color--200);
     color: var(--pf-global--Color--light-100);
-    .level-wrapper {
-      flex-direction: row;
-      justify-content: space-between;
-      padding-bottom: var(--pf-global--spacer--xl);
-      .tile {
-        flex-basis: 15%;
-        flex-direction: column;
-        margin-top: auto; // adjust for missing secton titles
-        .title {
-          font-size: var(--pf-global--FontSize--md);
-          padding-bottom: var(--pf-global--spacer--md);
-        }
-        .count {
-          font-size: var(--pf-global--FontSize--3xl);    
-        }
-        .name {
-          font-size: var(--pf-global--FontSize--sm);
-          margin-bottom: var(--pf-global--spacer--sm);
-        }
-        .label {
-          align-self:stretch;
-          .pf-c-label {
-            width: 100%;
-            --pf-c-label--FontSize: var(--pf-global--FontSize--xs);
-          }
-        }
-        .ins-m-hidden {
-          display: none !important;
-        }
-      }
-    }
   }
 
-@media screen and (min-width: 1200px) and (max-width: 1449px) {
-     .first-level {
-       .level-wrapper {
-         flex-basis: 100%;
-         justify-content: space-between;
-         .tile {
-           flex-basis: 30%;
-           --pf-l-flex--spacer: var(--pf-global--spacer--lg);
-           &:nth-of-type(3n+0) { --pf-l-flex--spacer: var(--pf-l-flex--spacer--none); }
-           &:nth-of-type(n+4) { padding-top: var(--pf-global--spacer--lg); }
-         }
-       }
-     }
-   }
 
-  @media screen and (max-width: 1199px) {
-    .first-level {
-      padding-right: var(--pf-global--spacer--lg);
-      .level-wrapper {
-        flex-direction: column;
-        width: 100%;
-        .tile {
-          flex-direction: row;
-          width: 100%;
-          &:first-of-type .title {
-            padding-top: var(--pf-global--spacer--none);
-          }
-          .title {
-            font-size: var(--pf-global--FontSize--xl);
-            padding-bottom: var(--pf-global--spacer--md);
-            padding-top: var(--pf-global--spacer--md);
-            &:empty {
-              display: none;
-            }
-          }
-          .count {
-            font-size: var(--pf-global--FontSize--xl);
-            padding-bottom: var(--pf-global--spacer--none);      
-          }
-          .name {
-            flex: 2;
-            flex-wrap: nowrap;
-          }
-          .label {
-            flex-basis: 30%;
-          }
-        }
-      }
-    }
-  }
 
   .second-level {
     background-color: var(--pf-global--BackgroundColor--100);


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-13163
Fixes the estate seaction after getting data from API.

Instead of a custom flex layout, it uses the description list. That can be further customized for smaller screens via its props. The DL will keep the rows horizontally and columns vertically aligned because its using a grid layout.

### Before
![screenshot-ci cloud redhat com-2021 03 24-15_19_48](https://user-images.githubusercontent.com/22619452/112325968-69164080-8cb4-11eb-829e-a0a3f58736a2.png)


### After

![screenshot-ci foo redhat com_1337-2021 03 24-15_21_32](https://user-images.githubusercontent.com/22619452/112326238-a4187400-8cb4-11eb-8112-de48d1b8c9ed.png)

