### PR TITLE
Fix double scrollbar.

### DIFF
--- a/src/routes/Landing.scss
+++ b/src/routes/Landing.scss
@@ -123,9 +123,6 @@ sup.ins-c-rball { @include rem('font-size', 10px); }
     .ins-c-page__landing-navigation {
         flex-shrink: 0;
     }
-    .pf-l-split__item {
-        overflow-y: auto;
-    }
 }
 
 .ins-c-page__landing-content {


### PR DESCRIPTION
Removes double scrollbar when hovering over truncated buttons (possibly just Linux thing)
![Screenshot from 2021-04-08 16-11-29](https://user-images.githubusercontent.com/22619452/114041830-27c18b80-9885-11eb-94c8-1c504227c196.png)
