### PR TITLE
Divide recommendations into sections

### DIFF
--- a/src/components/app-content-renderer/recommendation-tile.js
+++ b/src/components/app-content-renderer/recommendation-tile.js
@@ -23,10 +23,8 @@ const RecommendationGroup = (recommendation) => {
   const removeTile = ({ show }) =>
     show === false &&
     dispatch(removeRecommendationTile(recommendation.id, recommendation.recId));
-  const [{ count, response, show }] = useRequest(
-    recommendation,
-    removeTile,
-    () => removeTile({ show: false })
+  const [{ count, response }] = useRequest(recommendation, removeTile, () =>
+    removeTile({ show: false })
   );
 
   const text = (message) =>
@@ -36,26 +34,9 @@ const RecommendationGroup = (recommendation) => {
 
   const GroupIcon = iconMapper[recommendation.icon] || QuestionCircleIcon;
 
-  if (!show) {
-    return null;
-  }
-
-  if (recommendation.component === 'title') {
-    return (
-      <Title headingLevel="h2" size="md">
-        {recommendation.title}
-      </Title>
-    );
-  }
-
   return (
     <React.Fragment>
       <Flex direction={{ default: 'column' }} className="recommendation-test">
-        <Flex>
-          <Title headingLevel="h3" className="pf-u-mb-md">
-            Section title here
-          </Title>
-        </Flex>
         <Flex direction={{ default: 'row' }} className="recommendation-group">
           <FlexItem className="recommendation-icon">
             <GroupIcon
@@ -137,52 +118,26 @@ RecommendationGroup.defaultProps = {
   method: 'get',
 };
 
-const RecommendationSection = ({ groups, title, recId }) =>
-  groups.length === 0 ? null : (
-    <React.Fragment>
-      <Title headingLevel="h3" className="pf-u-mb-md">
+const RecommendationTile = ({ items, title, id }) =>
+  items.length > 0 ? (
+    <span>
+      <Title headingLevel="h3" size="lg">
         {title}
       </Title>
-      {groups.map((group, index) => (
-        <RecommendationGroup recId={recId} key={group.id || index} {...group} />
+      {items.map((group, index) => (
+        <RecommendationGroup recId={id} key={group.id || index} {...group} />
       ))}
-    </React.Fragment>
-  );
-
-RecommendationSection.propTypes = {
-  title: PropTypes.string,
-  groups: PropTypes.arrayOf(PropTypes.shape(RecommendationGroup.propTypes)),
-  recId: PropTypes.string,
-};
-
-RecommendationSection.defaultProps = {
-  groups: [],
-};
-
-const RecommendationTile = ({ groups, sections, id }) => (
-  <span>
-    {groups.map((group, index) => (
-      <RecommendationGroup recId={id} key={group.id || index} {...group} />
-    ))}
-    {sections.map((section, index) => (
-      <RecommendationSection
-        recId={id}
-        key={section.id || index}
-        {...section}
-      />
-    ))}
-  </span>
-);
+    </span>
+  ) : null;
 RecommendationTile.propTypes = {
-  groups: PropTypes.arrayOf(PropTypes.shape(RecommendationGroup.propTypes)),
-  sections: PropTypes.arrayOf(PropTypes.shape(RecommendationSection.propTypes)),
+  title: PropTypes.node.isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape(RecommendationGroup.propTypes)),
   countOfReccomentations: PropTypes.number.isRequired,
   id: PropTypes.string.isRequired,
 };
 
 RecommendationTile.defaultProps = {
-  groups: [],
-  sections: [],
+  items: [],
 };
 
 export default RecommendationTile;

--- a/src/components/app-content-renderer/recommendation-tile.js
+++ b/src/components/app-content-renderer/recommendation-tile.js
@@ -22,7 +22,9 @@ const RecommendationGroup = (recommendation) => {
   const dispatch = useDispatch();
   const removeTile = ({ show }) =>
     show === false &&
-    dispatch(removeRecommendationTile(recommendation.id, recommendation.recId));
+    dispatch(
+      removeRecommendationTile(recommendation.id, recommendation.category)
+    );
   const [{ count, response }] = useRequest(recommendation, removeTile, () =>
     removeTile({ show: false })
   );
@@ -76,7 +78,7 @@ const RecommendationGroup = (recommendation) => {
 RecommendationGroup.propTypes = {
   icon: PropTypes.string,
   state: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
-  recId: PropTypes.string,
+  category: PropTypes.string.isRequired,
   description: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.shape({
@@ -125,13 +127,17 @@ const RecommendationTile = ({ items, title, id }) =>
         {title}
       </Title>
       {items.map((group, index) => (
-        <RecommendationGroup recId={id} key={group.id || index} {...group} />
+        <RecommendationGroup category={id} key={group.id || index} {...group} />
       ))}
     </span>
   ) : null;
+
+const groupSchemaPropShape = (({ category, ...types }) => types)(
+  RecommendationGroup.propTypes
+);
 RecommendationTile.propTypes = {
   title: PropTypes.node.isRequired,
-  items: PropTypes.arrayOf(PropTypes.shape(RecommendationGroup.propTypes)),
+  items: PropTypes.arrayOf(PropTypes.shape(groupSchemaPropShape)),
   countOfReccomentations: PropTypes.number.isRequired,
   id: PropTypes.string.isRequired,
 };

--- a/src/contentApi/ansible-api.js
+++ b/src/contentApi/ansible-api.js
@@ -461,7 +461,7 @@ export const RECOMMENDATIONS_ITEMS = {
       },
       url: '/api/catalog/v1/portfolio_items?limit=5',
       accessor: 'data.length',
-      icon: 'unknown',
+      icon: 'history',
       permissions: [
         {
           method: 'hasPermissions',
@@ -482,7 +482,7 @@ export const RECOMMENDATIONS_ITEMS = {
       },
       url: '/api/catalog/v1/orders?limit=5',
       accessor: 'data.length',
-      icon: 'unknown',
+      icon: 'history',
       permissions: [
         {
           method: 'hasPermissions',

--- a/src/contentApi/ansible-api.js
+++ b/src/contentApi/ansible-api.js
@@ -451,78 +451,68 @@ const ansibleEstateRequests = [
   },
 ];
 
-export const RECOMMENDATIONS_ITEMS = [
-  {
-    title: 'Ansible recommendations',
-    id: 'ansiblerrecommendations',
-    sections: [
-      {
-        title: 'Catalog',
-        id: 'catalog',
-        groups: [
-          {
-            id: 'products',
-            description: {
-              id: 'last-added-products',
-              defaultMessage: 'Last added products ({count})',
-            },
-            url: '/api/catalog/v1/portfolio_items?limit=5',
-            accessor: 'data.length',
-            icon: 'unknown',
-            permissions: [
-              {
-                method: 'hasPermissions',
-                args: [['catalog:portfolio_items:read']],
-              },
-            ],
-            action: {
-              url:
-                'https://cloud.stage.redhat.com/docs/api/catalog#operations-PortfolioItem-listPortfolioItems',
-              title: 'Products',
-            },
-          },
-          {
-            id: 'orders',
-            description: {
-              id: 'last-added-orders',
-              defaultMessage: 'Last orders ({count})',
-            },
-            url: '/api/catalog/v1/orders?limit=5',
-            accessor: 'data.length',
-            icon: 'unknown',
-            permissions: [
-              {
-                method: 'hasPermissions',
-                args: [['catalog:orders:read', 'catalog:order_items:read']],
-              },
-            ],
-            action: {
-              url:
-                'https://cloud.stage.redhat.com/docs/api/catalog#operations-Order-listOrders',
-              title: 'Orders',
-            },
-          },
-          {
-            id: 'approvals',
-            description: `Approvals`,
-            icon: 'list',
-            state: 'info',
-            permissions: [
-              {
-                method: 'hasPermissions',
-                args: [['approval:requests:read']],
-              },
-            ],
-            action: {
-              url: './ansible/catalog/approval/requests',
-              title: 'Approvals',
-            },
-          },
-        ],
+export const RECOMMENDATIONS_ITEMS = {
+  recs: [
+    {
+      id: 'products',
+      description: {
+        id: 'last-added-products',
+        defaultMessage: 'Last added products ({count})',
       },
-    ],
-  },
-];
+      url: '/api/catalog/v1/portfolio_items?limit=5',
+      accessor: 'data.length',
+      icon: 'unknown',
+      permissions: [
+        {
+          method: 'hasPermissions',
+          args: [['catalog:portfolio_items:read']],
+        },
+      ],
+      action: {
+        url:
+          'https://cloud.stage.redhat.com/docs/api/catalog#operations-PortfolioItem-listPortfolioItems',
+        title: 'Products',
+      },
+    },
+    {
+      id: 'orders',
+      description: {
+        id: 'last-added-orders',
+        defaultMessage: 'Last orders ({count})',
+      },
+      url: '/api/catalog/v1/orders?limit=5',
+      accessor: 'data.length',
+      icon: 'unknown',
+      permissions: [
+        {
+          method: 'hasPermissions',
+          args: [['catalog:orders:read', 'catalog:order_items:read']],
+        },
+      ],
+      action: {
+        url:
+          'https://cloud.stage.redhat.com/docs/api/catalog#operations-Order-listOrders',
+        title: 'Orders',
+      },
+    },
+    {
+      id: 'approvals',
+      description: `Approvals`,
+      icon: 'list',
+      state: 'info',
+      permissions: [
+        {
+          method: 'hasPermissions',
+          args: [['approval:requests:read']],
+        },
+      ],
+      action: {
+        url: './ansible/catalog/approval/requests',
+        title: 'Approvals',
+      },
+    },
+  ],
+};
 
 export const getAnsibleDataSchema = () => ({
   firstPanel: ansibleEstateRequests,

--- a/src/contentApi/cloud-access-api.js
+++ b/src/contentApi/cloud-access-api.js
@@ -45,7 +45,7 @@ const CLOUD_ACCESS_CONFIGURE = [
 
 export const getCloudAccessDataSchema = () => ({
   firstPanel: [],
-  secondPanel: [],
+  secondPanel: {},
   configTryLearn: {
     configure: CLOUD_ACCESS_CONFIGURE,
     try: [],

--- a/src/contentApi/cost-api.js
+++ b/src/contentApi/cost-api.js
@@ -104,46 +104,38 @@ const costManagementApiMedium =
 export const getCostDataSchema = () => {
   return {
     firstPanel: estateRequests,
-    secondPanel: [
-      {
-        title: 'Cost management recommendations',
-        id: 'cost-recommendations',
-        sections: [
-          {
-            title: 'Cost management recommendations',
-            groups: [
-              {
-                icon: 'lightbulb',
-                state: 'info',
-                id: 'cost-ocp',
-                url: '/api/cost-management/v1/sources/?source_type=OCP',
-                accessor: 'meta.count',
-                permissions: [
-                  {
-                    method: 'isEntitled',
-                    args: ['cost_management'],
-                  },
-                ],
-                condition: {
-                  when: 'count',
-                  is: 0,
-                },
-                title: 'Gain Business Insights for your OpenShift Clusters',
-                description: '',
-                action: {
-                  title: 'Learn more',
-                  href: installCostOperator,
-                },
-              },
-            ],
+    secondPanel: {
+      openshift: [
+        {
+          section: 'openshift',
+          icon: 'lightbulb',
+          state: 'info',
+          id: 'cost-ocp',
+          url: '/api/cost-management/v1/sources/?source_type=OCP',
+          accessor: 'meta.count',
+          permissions: [
+            {
+              method: 'isEntitled',
+              args: ['cost_management'],
+            },
+          ],
+          condition: {
+            when: 'count',
+            is: 0,
           },
-        ],
-      },
-    ],
+          title: 'Gain Business Insights for your OpenShift Clusters',
+          description:
+            'Install the Cost Operator on your OpenShift cluster to get started.',
+          action: {
+            title: 'Learn more',
+            href: installCostOperator,
+          },
+        },
+      ],
+    },
     configTryLearn: {
       configure: [
         {
-          // icon: 'connected',
           shape: {
             title: 'Add public cloud sources to better track your finances',
             description: 'Modify user access to applications.',
@@ -162,7 +154,6 @@ export const getCostDataSchema = () => {
       ],
       try: [
         {
-          // icon: 'builderImage',
           shape: {
             title: 'Cost Management now has forecasting',
             description:
@@ -180,7 +171,6 @@ export const getCostDataSchema = () => {
           ],
         },
         {
-          // icon: 'builderImage',
           shape: {
             title: 'Cost Management supports Google Cloud Platform',
             description:

--- a/src/contentApi/create-content-data.js
+++ b/src/contentApi/create-content-data.js
@@ -3,27 +3,76 @@ import getAppsData from './get-apps-data';
 const createContentData = async () => {
   const data = await getAppsData();
   const landingPageContent = data.reduce(
-    (acc, { firstPanel, secondPanel, configTryLearn }) => ({
-      estate: [...acc.estate, ...firstPanel],
-      recommendations: [...acc.recommendations, ...secondPanel],
-      configTryLearn: [
-        {
-          ...acc.configTryLearn[0],
-          items: [...acc.configTryLearn[0].items, ...configTryLearn.configure],
+    (acc, { firstPanel, secondPanel, configTryLearn }) => {
+      const {
+        recs = [],
+        rhel = [],
+        ansible = [],
+        openshift = [],
+      } = secondPanel;
+      return {
+        estate: [...acc.estate, ...firstPanel],
+        recommendations: {
+          recs: {
+            ...acc.recommendations.recs,
+            items: [...acc.recommendations.recs.items, ...recs],
+          },
+          rhel: {
+            ...acc.recommendations.rhel,
+            items: [...acc.recommendations.rhel.items, ...rhel],
+          },
+          ansible: {
+            ...acc.recommendations.ansible,
+            items: [...acc.recommendations.ansible.items, ...ansible],
+          },
+          openshift: {
+            ...acc.recommendations.openshift,
+            items: [...acc.recommendations.openshift.items, ...openshift],
+          },
         },
-        {
-          ...acc.configTryLearn[1],
-          items: [...acc.configTryLearn[1].items, ...configTryLearn.try],
-        },
-        {
-          ...acc.configTryLearn[2],
-          items: [...acc.configTryLearn[2].items, ...configTryLearn.learn],
-        },
-      ],
-    }),
+        configTryLearn: [
+          {
+            ...acc.configTryLearn[0],
+            items: [
+              ...acc.configTryLearn[0].items,
+              ...configTryLearn.configure,
+            ],
+          },
+          {
+            ...acc.configTryLearn[1],
+            items: [...acc.configTryLearn[1].items, ...configTryLearn.try],
+          },
+          {
+            ...acc.configTryLearn[2],
+            items: [...acc.configTryLearn[2].items, ...configTryLearn.learn],
+          },
+        ],
+      };
+    },
     {
       estate: [],
-      recommendations: [],
+      recommendations: {
+        recs: {
+          title: 'Recommendations',
+          id: 'recommendations',
+          items: [],
+        },
+        rhel: {
+          title: 'Insights for RHEL',
+          id: 'rhel',
+          items: [],
+        },
+        ansible: {
+          title: 'Insights for Ansible',
+          id: 'ansible',
+          items: [],
+        },
+        openshift: {
+          title: 'Insights for OpenShift',
+          id: 'openshift',
+          items: [],
+        },
+      },
       configTryLearn: [
         {
           id: 'configure',
@@ -43,6 +92,12 @@ const createContentData = async () => {
       ],
     }
   );
+  landingPageContent.recommendations = [
+    { ...landingPageContent.recommendations.recs },
+    { ...landingPageContent.recommendations.openshift },
+    { ...landingPageContent.recommendations.rhel },
+    { ...landingPageContent.recommendations.ansible },
+  ];
   return landingPageContent;
 };
 

--- a/src/contentApi/create-content-data.js
+++ b/src/contentApi/create-content-data.js
@@ -1,35 +1,25 @@
 import getAppsData from './get-apps-data';
+import defaultConfig from '../utils/default-content-config.json';
+
+const recommendationsCategories = ['recs', 'rhel', 'ansible', 'openshift'];
 
 const createContentData = async () => {
   const data = await getAppsData();
   const landingPageContent = data.reduce(
     (acc, { firstPanel, secondPanel, configTryLearn }) => {
-      const {
-        recs = [],
-        rhel = [],
-        ansible = [],
-        openshift = [],
-      } = secondPanel;
+      const recommendations = { ...acc.recommendations };
+      recommendationsCategories.forEach((category) => {
+        recommendations[category] = {
+          ...acc.recommendations[category],
+          items: [
+            ...acc.recommendations[category].items,
+            ...(secondPanel[category] || []),
+          ],
+        };
+      });
       return {
         estate: [...acc.estate, ...firstPanel],
-        recommendations: {
-          recs: {
-            ...acc.recommendations.recs,
-            items: [...acc.recommendations.recs.items, ...recs],
-          },
-          rhel: {
-            ...acc.recommendations.rhel,
-            items: [...acc.recommendations.rhel.items, ...rhel],
-          },
-          ansible: {
-            ...acc.recommendations.ansible,
-            items: [...acc.recommendations.ansible.items, ...ansible],
-          },
-          openshift: {
-            ...acc.recommendations.openshift,
-            items: [...acc.recommendations.openshift.items, ...openshift],
-          },
-        },
+        recommendations,
         configTryLearn: [
           {
             ...acc.configTryLearn[0],
@@ -49,48 +39,7 @@ const createContentData = async () => {
         ],
       };
     },
-    {
-      estate: [],
-      recommendations: {
-        recs: {
-          title: 'Recommendations',
-          id: 'recommendations',
-          items: [],
-        },
-        rhel: {
-          title: 'Insights for RHEL',
-          id: 'rhel',
-          items: [],
-        },
-        ansible: {
-          title: 'Insights for Ansible',
-          id: 'ansible',
-          items: [],
-        },
-        openshift: {
-          title: 'Insights for OpenShift',
-          id: 'openshift',
-          items: [],
-        },
-      },
-      configTryLearn: [
-        {
-          id: 'configure',
-          title: 'Configure',
-          items: [],
-        },
-        {
-          id: 'try',
-          title: 'Try',
-          items: [],
-        },
-        {
-          id: 'learn',
-          title: 'Learn',
-          items: [],
-        },
-      ],
-    }
+    defaultConfig
   );
   landingPageContent.recommendations = [
     { ...landingPageContent.recommendations.recs },

--- a/src/contentApi/fifi-api.js
+++ b/src/contentApi/fifi-api.js
@@ -1,57 +1,39 @@
-const FIFI_RECOMMENDATIONS = [
-  {
-    title: 'Remediate with Ansible',
-    id: 'fifirecommendations',
-    sections: [
-      {
-        title: 'Advisor recommendations',
-        id: 'fifi',
-        groups: [
-          {
-            id: 'fifi-1',
-            icon: 'cog',
-            title:
-              'Create an Ansible Playbook to remediate or mitigate vulnerabilities or configuration issues.',
-            action: {
-              title: 'View',
-              href: './insights/advisor',
-            },
-          },
-        ],
+const FIFI_RECOMMENDATIONS = {
+  recs: [
+    {
+      id: 'fifi-1',
+      icon: 'cog',
+      title:
+        'Create an Ansible Playbook to remediate or mitigate vulnerabilities or configuration issues.',
+      action: {
+        title: 'View',
+        href: './insights/advisor',
       },
-      {
-        title: 'Compliance recommendations',
-        groups: [
-          {
-            id: 'fifi-2',
-            icon: 'cog',
-            title:
-              'Create an Ansible Playbook to remediate or mitigate vulnerabilities or configuration issues.',
-            action: {
-              title: 'View',
-              href: './insights/compliance/reports',
-            },
-          },
-        ],
+    },
+
+    {
+      id: 'fifi-2',
+      icon: 'cog',
+      title:
+        'Create an Ansible Playbook to remediate or mitigate vulnerabilities or configuration issues.',
+      action: {
+        title: 'View',
+        href: './insights/compliance/reports',
       },
-      {
-        title: 'Vulnerability recommendations',
-        groups: [
-          {
-            id: 'fifi-3',
-            icon: 'cog',
-            title:
-              'Create an Ansible Playbook to remediate or mitigate vulnerabilities or configuration issues.',
-            action: {
-              title: 'View',
-              href: './insights/vulnerability',
-            },
-          },
-        ],
+    },
+
+    {
+      id: 'fifi-3',
+      icon: 'cog',
+      title:
+        'Create an Ansible Playbook to remediate or mitigate vulnerabilities or configuration issues.',
+      action: {
+        title: 'View',
+        href: './insights/vulnerability',
       },
-    ],
-  },
-];
+    },
+  ],
+};
 
 const FIFI_LEARN = [
   {

--- a/src/contentApi/rhel.js
+++ b/src/contentApi/rhel.js
@@ -15,85 +15,76 @@ const registerLink = `${prefix}insights/registration`;
 
 const remediations = `${prefix}insights/remediations`;
 
-const RECOMMENDATIONS_ITEMS = [
-  {
-    title: 'RHEL recommendations',
-    id: 'rhel-recommendations',
-    sections: [
-      {
-        title: 'RHEL recommendations',
-        groups: [
-          {
-            id: 'rhel-2',
-            icon: 'error',
-            state: 'error',
-            url: '/api/insights/v1/rule/?impacting=true&limit=1&incident=true',
-            title: {
-              id: 'rhen-incidents-recommendation',
-              defaultMessage:
-                'Insights has identified {count} incidents affecting your systems.',
-            },
-            accessor: 'meta.count',
-            condition: {
-              when: 'count',
-              isNot: 0,
-            },
-            action: {
-              title: 'View',
-            },
-            permissions: [
-              {
-                method: 'hasPermissions',
-                args: [['advisor:*:*']],
-              },
-            ],
-          },
-          // {
-          //   id: 'rhel-3',
-          //   title: 'Newly released security rule: [Security rule name]',
-          //   action: {
-          //     title: 'View rule',
-          //   },
-          //   permissions: [
-          //     {
-          //       method: 'hasPermissions',
-          //       args: [['vulnerability:*:*']],
-          //     },
-          //   ],
-          // },
-          {
-            id: 'rhel-5',
-            icon: 'cog',
-            title:
-              'Create a remediation playbook to fix issues identified by Insights on your systems',
-            action: {
-              title: 'Open',
-              href: remediations,
-            },
-            permissions: [
-              {
-                method: 'hasPermissions',
-                args: [['remediations:*:*']],
-              },
-            ],
-          },
-          {
-            url: '/api/inventory/v1/hosts',
-            icon: 'play',
-            state: 'success',
-            condition: { when: 'total', is: 0 },
-            id: 'rhel-6',
-            title: 'Get Insights for your systems',
-            action: {
-              title: 'Register systems',
-              href: registerLink,
-            },
-          },
-        ],
+const RECOMMENDATIONS_ITEMS = {
+  rhel: [
+    {
+      id: 'rhel-2',
+      icon: 'error',
+      state: 'error',
+      url: '/api/insights/v1/rule/?impacting=true&limit=1&incident=true',
+      title: {
+        id: 'rhen-incidents-recommendation',
+        defaultMessage:
+          'Insights has identified {count} incidents affecting your systems.',
       },
-    ],
-  },
-];
+      accessor: 'meta.count',
+      condition: {
+        when: 'count',
+        isNot: 0,
+      },
+      action: {
+        title: 'View',
+      },
+      permissions: [
+        {
+          method: 'hasPermissions',
+          args: [['advisor:*:*']],
+        },
+      ],
+    },
+    // {
+    //   id: 'rhel-3',
+    //   title: 'Newly released security rule: [Security rule name]',
+    //   action: {
+    //     title: 'View rule',
+    //   },
+    //   permissions: [
+    //     {
+    //       method: 'hasPermissions',
+    //       args: [['vulnerability:*:*']],
+    //     },
+    //   ],
+    // },
+    {
+      id: 'rhel-5',
+      icon: 'cog',
+      title:
+        'Create a remediation playbook to fix issues identified by Insights on your systems',
+      action: {
+        title: 'Open',
+        href: remediations,
+      },
+      permissions: [
+        {
+          method: 'hasPermissions',
+          args: [['remediations:*:*']],
+        },
+      ],
+    },
+    {
+      url: '/api/inventory/v1/hosts',
+      icon: 'play',
+      state: 'success',
+      condition: { when: 'total', is: 0 },
+      id: 'rhel-6',
+      title: 'Get Insights for your systems',
+      action: {
+        title: 'Register systems',
+        href: registerLink,
+      },
+    },
+  ],
+};
 
 const ESTATE_CONFIG = [
   {

--- a/src/contentApi/rhel.js
+++ b/src/contentApi/rhel.js
@@ -101,8 +101,10 @@ const ESTATE_CONFIG = [
         },
         permissions: [
           {
-            method: 'hasPermissions',
-            args: [['inventory:*:*']],
+            method: 'loosePermissions',
+            args: [
+              ['inventory:*:*', 'inventory:*:read', 'inventory:hosts:read'],
+            ],
           },
         ],
       },
@@ -117,8 +119,10 @@ const ESTATE_CONFIG = [
         },
         permissions: [
           {
-            method: 'hasPermissions',
-            args: [['inventory:*:*']],
+            method: 'loosePermissions',
+            args: [
+              ['inventory:*:*', 'inventory:*:read', 'inventory:hosts:read'],
+            ],
           },
         ],
       },
@@ -142,8 +146,10 @@ const ESTATE_CONFIG = [
         id: 'rhel-sap-systems',
         permissions: [
           {
-            method: 'hasPermissions',
-            args: [['inventory:*:*']],
+            method: 'loosePermissions',
+            args: [
+              ['inventory:*:*', 'inventory:*:read', 'inventory:hosts:read'],
+            ],
           },
         ],
         responseProcessor: totalResponseProcessor,

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -14,10 +14,10 @@ export const removeEstateTile = (tileId) => ({
   payload: tileId,
 });
 
-export const removeRecommendationTile = (tileId, recId) => ({
+export const removeRecommendationTile = (tileId, category) => ({
   type: REMOVE_RECOMMENDATION_TILE,
   payload: {
     tileId,
-    recId,
+    category,
   },
 });

--- a/src/store/contentReducer.js
+++ b/src/store/contentReducer.js
@@ -30,26 +30,21 @@ export function removeEstateTile(state, { payload }) {
   };
 }
 
-function removeTileFromSections({ sections = [], ...recommendation }, tileId) {
+function removeTileFromSections({ items = [], ...recommendation }, tileId) {
   return {
     ...recommendation,
-    sections: sections.map(({ groups = [], ...section }) => ({
-      ...section,
-      groups: groups.filter(({ id }) => id !== tileId),
-    })),
+    items: items.filter(({ id }) => id !== tileId),
   };
 }
 
 export function removeRecommendationTile(
   state,
-  { payload: { tileId, recId } }
+  { payload: { tileId, category } }
 ) {
   return {
     ...state,
-    recommendations: state.recommendations.map((recommendations) =>
-      recommendations.id === recId
-        ? removeTileFromSections(recommendations, tileId)
-        : recommendations
+    recommendations: state.recommendations.map((group) =>
+      group.id === category ? removeTileFromSections(group, tileId) : group
     ),
   };
 }

--- a/src/utils/default-content-config.json
+++ b/src/utils/default-content-config.json
@@ -1,0 +1,107 @@
+{
+  "estate": [],
+  "recommendations": {
+    "recs": {
+      "title": "Recommendations",
+      "id": "recommendations",
+      "items": []
+    },
+    "rhel": {
+      "title": "Insights for RHEL",
+      "id": "rhel",
+      "items": [{
+        "id": "rhel-default-1",
+        "permissions": [{
+          "method": "isNotEntitled",
+          "args": ["rhel"]
+        }],
+        "icon": "play",
+        "state": "success",
+        "title": "Red Hat Insights for Red Hat Enterprise Linux simplifies how IT teams maintain and optimize a stable, secure, and performant operating environment.",
+        "action": {
+          "title": "Try It",
+          "href": "https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/try-it"
+        }
+      }, {
+        "id": "rhel-default-2",
+        "permissions": [{
+          "method": "isNotEntitled",
+          "args": ["rhel"]
+        }],
+        "icon": "play",
+        "state": "success",
+        "title": "Your account team can set up Subscriptions to report on your Red Hat Enterprise Linux subscription usage.",
+        "action": {
+          "title": "Contact Us",
+          "href": "https://access.redhat.com/account-team "
+        }
+      }]
+    },
+    "ansible": {
+      "title": "Insights for Ansible",
+      "id": "ansible",
+      "items": [{
+        "id": "ansible-default-1",
+        "permissions": [{
+          "method": "isNotEntitled",
+          "args": ["ansible"]
+        }],
+        "icon": "play",
+        "state": "success",
+        "title": "Red Hat Ansible Automation Platform provides analytics and knowledge on your automation, access to certified content, and more.",
+        "action": {
+          "title": "Try it",
+          "href": "https://www.redhat.com/en/technologies/management/ansible/try-it"
+        }
+      }]
+    },
+    "openshift": {
+      "title": "Insights for OpenShift",
+      "id": "openshift",
+      "items": [{
+        "id": "openshift-default-1",
+        "permissions": [{
+          "method": "isNotEntitled",
+          "args": ["openshift"]
+        }],
+        "icon": "play",
+        "state": "success",
+        "title": "Your account team can set up Subscriptions to report on your Red Hat OpenShift Container subscription usage.",
+        "action": {
+          "title": "Contact Us",
+          "href": "https://access.redhat.com/account-team"
+        }
+      }, {
+        "id": "openshift-default-2",
+        "permissions": [{
+          "method": "isNotEntitled",
+          "args": ["openshift"]
+        }],
+        "icon": "play",
+        "state": "success",
+        "title": "Red Hat OpenShift customers have access to Cost Management, which provides visibility and analysis for your OpenShift and cloud costs.",
+        "action": {
+          "title": "Learn More",
+          "href": "https://www.redhat.com/en/technologies/cloud-computing/openshift"
+        }
+      }]
+    }
+  },
+  "configTryLearn": [
+    {
+      "id": "configure",
+      "title": "Configure",
+      "items": []
+    },
+    {
+      "id": "try",
+      "title": "Try",
+      "items": []
+    },
+    {
+      "id": "learn",
+      "title": "Learn",
+      "items": []
+    }
+  ]
+}


### PR DESCRIPTION
### Changes
- divide all reccommendations into 4 categories
- add missing icons
- adjust RHEL estate permission rules (does not show anything in prod even though the user can access dashboard with the data)
- added default content to each recommendation category

![screenshot-prod foo redhat com_1337-2021 04 09-10_52_06](https://user-images.githubusercontent.com/22619452/114157496-fba91780-9923-11eb-9aaf-95e6f29b8daa.png)

