### PR TITLE
Add estate scroll

### DIFF
--- a/src/components/app-content-renderer/config-try-learn-tile.js
+++ b/src/components/app-content-renderer/config-try-learn-tile.js
@@ -107,7 +107,6 @@ const ConfigTryLearnTile = ({ title, column, items, sectionName }) => {
           alignItems={{ default: 'alignItemsFlexEnd' }}
           className="pf-u-mb-lg"
           style={{ gridRow: 1 }}
-          hasGutter
         >
           <FlexItem>
             <Icon size="md" />

--- a/src/components/app-content-renderer/first-panel.js
+++ b/src/components/app-content-renderer/first-panel.js
@@ -61,7 +61,6 @@ const FirstPanel = () => {
   );
 
   useEffect(() => {
-    console.log(scrollRef);
     const wheelHandler = (event) => scrollhandler(event, scrollRef.current);
     scrollRef.current.addEventListener('wheel', wheelHandler);
     return () => {

--- a/src/components/app-content-renderer/first-panel.js
+++ b/src/components/app-content-renderer/first-panel.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 import { shallowEqual, useSelector } from 'react-redux';
 
@@ -35,13 +35,42 @@ const flattenSections = (estates) =>
       return result;
     });
 
+const scrollhandler = (event, element) => {
+  /**
+   * allow verticall scroll if we can't scroll to the right or left anymore
+   */
+  if (
+    (element.scrollWidth - element.offsetWidth - element.scrollLeft === 0 &&
+      event.deltaY >= 0) ||
+    (element.scrollLeft === 0 && event.deltaY <= 0)
+  ) {
+    return;
+  }
+  /**
+   * Stop vertical scroll
+   */
+  event.preventDefault();
+  element.scrollLeft += event.deltaY;
+};
+
 const FirstPanel = () => {
+  const scrollRef = useRef(null);
   const estate = useSelector(
     ({ contentStore: { estate } }) => estate,
     shallowEqual
   );
+
+  useEffect(() => {
+    console.log(scrollRef);
+    const wheelHandler = (event) => scrollhandler(event, scrollRef.current);
+    scrollRef.current.addEventListener('wheel', wheelHandler);
+    return () => {
+      scrollRef.current.removeEventListener('wheel', wheelHandler);
+    };
+  }, []);
+
   return (
-    <div className="first-panel">
+    <div ref={scrollRef} className="first-panel">
       <DescriptionList>
         <EstateRenderer sections={flattenSections(estate)} />
       </DescriptionList>

--- a/src/components/app-content-renderer/recommendation-tile.js
+++ b/src/components/app-content-renderer/recommendation-tile.js
@@ -17,7 +17,11 @@ import iconMapper from '../../utils/icon-mapper';
 import { useDispatch } from 'react-redux';
 import { removeRecommendationTile } from '../../store/actions';
 
-const RecommendationGroup = (recommendation) => {
+const RecommendationGroup = ({
+  sectionTitle,
+  showSectionTitle,
+  ...recommendation
+}) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const removeTile = ({ show }) =>
@@ -37,41 +41,42 @@ const RecommendationGroup = (recommendation) => {
   const GroupIcon = iconMapper[recommendation.icon] || QuestionCircleIcon;
 
   return (
-    <React.Fragment>
-      <Flex direction={{ default: 'column' }} className="recommendation-test">
-        <Flex direction={{ default: 'row' }} className="recommendation-group">
-          <FlexItem className="recommendation-icon">
-            <GroupIcon
-              className={classnames({
-                error: recommendation.state === 'error',
-                warning: recommendation.state === 'warning',
-                info: recommendation.state === 'info',
-                green: recommendation.state === 'success',
-                gray: typeof recommendation.state === 'undefined',
-              })}
-            />
-          </FlexItem>
-          <FlexItem grow={{ default: 'grow' }}>
-            <TextContent>
-              {recommendation.title && (
-                <Text>{text(recommendation.title)}</Text>
-              )}
-              <Text>{text(recommendation.description)}</Text>
-            </TextContent>
-          </FlexItem>
-          <FlexItem>
-            <Button
-              component="a"
-              href={recommendation.action.href}
-              variant="secondary"
-              isSmall
-            >
-              {text(recommendation.action.title)}
-            </Button>
-          </FlexItem>
-        </Flex>
+    <Flex direction={{ default: 'column' }} className="recommendation-test">
+      {showSectionTitle && (
+        <Title headingLevel="h3" size="lg">
+          {sectionTitle}
+        </Title>
+      )}
+      <Flex direction={{ default: 'row' }} className="recommendation-group">
+        <FlexItem className="recommendation-icon">
+          <GroupIcon
+            className={classnames({
+              error: recommendation.state === 'error',
+              warning: recommendation.state === 'warning',
+              info: recommendation.state === 'info',
+              green: recommendation.state === 'success',
+              gray: typeof recommendation.state === 'undefined',
+            })}
+          />
+        </FlexItem>
+        <FlexItem grow={{ default: 'grow' }}>
+          <TextContent>
+            {recommendation.title && <Text>{text(recommendation.title)}</Text>}
+            <Text>{text(recommendation.description)}</Text>
+          </TextContent>
+        </FlexItem>
+        <FlexItem>
+          <Button
+            component="a"
+            href={recommendation.action.href}
+            variant="secondary"
+            isSmall
+          >
+            {text(recommendation.action.title)}
+          </Button>
+        </FlexItem>
       </Flex>
-    </React.Fragment>
+    </Flex>
   );
 };
 
@@ -113,6 +118,8 @@ RecommendationGroup.propTypes = {
   }),
   accessor: PropTypes.string,
   method: PropTypes.oneOf(['get', 'post']),
+  sectionTitle: PropTypes.string.isRequired,
+  showSectionTitle: PropTypes.bool.isRequired,
 };
 
 RecommendationGroup.defaultProps = {
@@ -123,18 +130,24 @@ RecommendationGroup.defaultProps = {
 const RecommendationTile = ({ items, title, id }) =>
   items.length > 0 ? (
     <span>
-      <Title headingLevel="h3" size="lg">
-        {title}
-      </Title>
       {items.map((group, index) => (
-        <RecommendationGroup category={id} key={group.id || index} {...group} />
+        <RecommendationGroup
+          sectionTitle={title}
+          showSectionTitle={index === 0}
+          category={id}
+          key={group.id || index}
+          {...group}
+        />
       ))}
     </span>
   ) : null;
 
-const groupSchemaPropShape = (({ category, ...types }) => types)(
-  RecommendationGroup.propTypes
-);
+const groupSchemaPropShape = (({
+  category,
+  sectionTitle,
+  showSectionTitle,
+  ...types
+}) => types)(RecommendationGroup.propTypes);
 RecommendationTile.propTypes = {
   title: PropTypes.node.isRequired,
   items: PropTypes.arrayOf(PropTypes.shape(groupSchemaPropShape)),

--- a/src/components/app-content-renderer/styles/panels.scss
+++ b/src/components/app-content-renderer/styles/panels.scss
@@ -31,7 +31,7 @@
     background: url(https://raw.githubusercontent.com/RedHatInsights/frontend-assets/master/src/background-images/new-landing-page/estate-double_gradient.svg);
     background-size: cover !important;
     padding: var(--pf-global--spacer--xl) var(--pf-global--spacer--lg) var(--pf-global--spacer--lg) var(--pf-global--spacer--lg);
-    overflow-x: scroll;
+    overflow-x: auto;
 
     @media only screen and (min-width: 769px) {
       .pf-c-description-list {


### PR DESCRIPTION
### Changes
- allow estate section scroll on `wheel` event 
- use `overflow-x: auto` on the estate section to hide the scrollbar if there is nowhere to scroll
- move section title to first section tile

@epwinchell @rvsia can you guys try how this behaves on MacOS? I know Eric was saying that the mouse wheel scroll of the state section worked before. Unfortunately, that is not the case on Linux and most likely on windows.

### Scroll
![scroll](https://user-images.githubusercontent.com/22619452/114167505-4f6d2e00-992f-11eb-9d3b-fea629488bfc.gif)

### Scrollbar on large
![screenshot-ci cloud redhat com-2021 04 09-12_31_45](https://user-images.githubusercontent.com/22619452/114167722-99eeaa80-992f-11eb-8b95-14a41e431fae.png)


### No scrollbar on large
![screenshot-prod foo redhat com_1337-2021 04 09-12_31_19](https://user-images.githubusercontent.com/22619452/114167702-93f8c980-992f-11eb-9122-5ee8420dcadf.png)
