### PR TITLE
Gate empty recommendation tile description tag.

### DIFF
--- a/src/components/app-content-renderer/recommendation-tile.js
+++ b/src/components/app-content-renderer/recommendation-tile.js
@@ -62,7 +62,9 @@ const RecommendationGroup = ({
         <FlexItem grow={{ default: 'grow' }}>
           <TextContent>
             {recommendation.title && <Text>{text(recommendation.title)}</Text>}
-            <Text>{text(recommendation.description)}</Text>
+            {recommendation.description && (
+              <Text>{text(recommendation.description)}</Text>
+            )}
           </TextContent>
         </FlexItem>
         <FlexItem>


### PR DESCRIPTION
The description prop in recommendation tile can be sometimes empty which leaves an extra empty `p` tag in the DOM.