### PR TITLE
tweak recommendations spacing

### DIFF
--- a/src/components/app-content-renderer/recommendation-tile.js
+++ b/src/components/app-content-renderer/recommendation-tile.js
@@ -41,7 +41,7 @@ const RecommendationGroup = ({
   const GroupIcon = iconMapper[recommendation.icon] || QuestionCircleIcon;
 
   return (
-    <Flex direction={{ default: 'column' }} className="recommendation-test">
+    <Flex direction={{ default: 'column' }} className="recommendation-section">
       {showSectionTitle && (
         <Title headingLevel="h3" size="lg">
           {sectionTitle}

--- a/src/components/app-content-renderer/styles/panels.scss
+++ b/src/components/app-content-renderer/styles/panels.scss
@@ -121,15 +121,14 @@
       overflow: hidden; // prevents padding from spilling into next column
       break-inside: avoid-column; // prevents padding from spilling into next column
 
-      .recommendation-test {
+      .recommendation-section {
         break-inside: avoid-column; // prevents padding from spilling into next column
         flex-wrap: nowrap;
-        min-height: 60px;
       }
 
       .recommendation-group {
         flex-wrap: nowrap;
-        margin-bottom: var(--pf-global--spacer--xs);
+        margin-bottom: var(--pf-global--spacer--sm);
         width: 100%;
         p {
           font-size: var(--pf-global--FontSize--sm);


### PR DESCRIPTION
Tweaks to the Recommendations section

- remove the min-height from section (previously prevented section title from being stuck at the bottom of a column)
- bump the padding between groups

Old
![Screen Shot 2021-04-15 at 8 52 32 AM](https://user-images.githubusercontent.com/1287144/114872253-22ee6180-9dc8-11eb-94c1-311df5e7f9b5.png)

New
![Screen Shot 2021-04-15 at 8 49 19 AM](https://user-images.githubusercontent.com/1287144/114872255-22ee6180-9dc8-11eb-8d7f-bbb1b6b6a772.png)


