### PR TITLE
Estate section skeleton tweak

### DIFF
--- a/src/components/app-content-renderer/styles/panels.scss
+++ b/src/components/app-content-renderer/styles/panels.scss
@@ -33,6 +33,13 @@
     padding: var(--pf-global--spacer--xl) var(--pf-global--spacer--lg) var(--pf-global--spacer--lg) var(--pf-global--spacer--lg);
     overflow-x: auto;
 
+    .ins-c-skeleton {
+      animation-duration: 3s;
+      &.ins-m-dark {
+        background: linear-gradient(to right, rgba(60,60,60,.2) 10%, rgba(72,72,72,.4) 18%, rgba(60,60,60,.2) 33%);
+      }
+    }
+
     @media only screen and (min-width: 769px) {
       .pf-c-description-list {
         display: flex;


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-13189

Adding some transparency to the Estate section skeleton to jibe better with the background image.  For whatever reason, overriding the linear-gradient threw off the animation timing, so I adjusted for that as well.

Old
![Screen Shot 2021-04-15 at 2 07 34 PM](https://user-images.githubusercontent.com/1287144/114917474-fc462000-9df3-11eb-88a2-4f1b1911e8fc.png)

New
![Screen Shot 2021-04-15 at 2 28 25 PM](https://user-images.githubusercontent.com/1287144/114919997-f6057300-9df6-11eb-8955-f234c37751f8.png)


