### PR TITLE
Fix estate tiles overlap.

### DIFF
--- a/src/components/app-content-renderer/first-panel.js
+++ b/src/components/app-content-renderer/first-panel.js
@@ -68,10 +68,13 @@ const FirstPanel = () => {
     };
   }, []);
 
-  return estate?.length > 0 ? (
+  const flatSections = flattenSections(estate || []);
+  return flatSections.length > 0 ? (
     <div ref={scrollRef} className="ins-l-first-panel">
-      <DescriptionList>
-        <EstateRenderer sections={flattenSections(estate)} />
+      <DescriptionList
+        style={{ gridTemplateColumns: `repeat(${flatSections.length}, 140px)` }}
+      >
+        <EstateRenderer sections={flatSections} />
       </DescriptionList>
     </div>
   ) : null;

--- a/src/components/app-content-renderer/styles/panels.scss
+++ b/src/components/app-content-renderer/styles/panels.scss
@@ -40,7 +40,6 @@
 
     @media screen and (min-width: $pf-global--breakpoint--md) {
       .pf-c-description-list {
-        display: flex;
         align-items: normal;
         .estate-group {
           margin-right: var(--pf-global--spacer--md);
@@ -77,6 +76,8 @@
     @media only screen and (max-width: $pf-global--breakpoint--md) {
       .pf-c-description-list {
         row-gap: 0;
+        display: flex;
+        flex-direction: column;
         .estate-group {
           display: flex;
           flex-wrap: wrap;


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-13817

Tiles are overlapping each other. To fix it, we use a grid layout with a fixed number of columns based on the number of estate items and fixed column width of 140px (same as before?).

Ignore long ansible text in after screenshots. I've added it to check if ellipsis overflow still works.

### Before
![screenshot-ci cloud redhat com-2021 04 22-09_33_50](https://user-images.githubusercontent.com/22619452/115674947-73c50380-a34e-11eb-9755-8c9cfb6db13c.png)

![screenshot-ci cloud redhat com-2021 04 22-09_37_34](https://user-images.githubusercontent.com/22619452/115674957-76275d80-a34e-11eb-82bc-0d9957abc4c8.png)

### After
![screenshot-ci foo redhat com_1337-2021 04 22-09_34_09](https://user-images.githubusercontent.com/22619452/115675106-948d5900-a34e-11eb-8d37-3091045760d8.png)

![screenshot-ci foo redhat com_1337-2021 04 22-09_38_41](https://user-images.githubusercontent.com/22619452/115675116-96efb300-a34e-11eb-96ad-3698c5ae4988.png)
