### PR TITLE
Update the GCP description for Cost Management

### DIFF
--- a/src/contentApi/cost-api.js
+++ b/src/contentApi/cost-api.js
@@ -148,7 +148,7 @@ export const getCostDataSchema = () => {
           shape: {
             title: 'Cost Management supports Google Cloud Platform',
             description:
-              'We can track your OpenShift cluster running on Google Cloud Platform spend.',
+              'We can track your Google Cloud Platform spend.',
             link: {
               title: 'Get started',
               href: './settings/sources/new',


### PR DESCRIPTION
We need to update the GCP description for Cost Management. The current description implies that we support OpenShift on Google Cloud Platform, which is not true.