### PR TITLE
make app services return a 200

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11258,6 +11258,11 @@
       "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@redhat-cloud-services/frontend-components-notifications": "^3.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "^3.1.1",
     "classnames": "^2.2.6",
+    "js-cookie": "^2.2.1",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",

--- a/src/contentApi/request-processor.js
+++ b/src/contentApi/request-processor.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import Cookies from 'js-cookie';
 
 import {
   hasPermissions as hasPermissionsEnhanced,
@@ -19,6 +20,14 @@ const enhancedFunctions = {
 };
 
 const ALLOWED_API_METHODS = ['get', 'post'];
+
+// the Authorization header is needed for api.openshift, 3scale will set this for all CRC hosted APIs, but not openshift :(
+const headers = {
+  Accept: 'application/json',
+  Authorization: `Bearer ${Cookies.get('cs_jwt')}`,
+  'Content-Type': 'application/json',
+};
+
 export const processRequest = async ({
   method = 'get',
   args = [],
@@ -46,6 +55,7 @@ export const processRequest = async ({
        */
       response = await fetch(url, {
         method,
+        headers,
         data: JSON.stringify(args[0]),
       }).then((d) => d.json());
     }


### PR DESCRIPTION
api.openshift requires the `Authorization` header. 3scale will actually set headers for us for CRC hosted APIs, but openshift does not.