### PR TITLE
Add check for account number before calling any request

### DIFF
--- a/src/contentApi/request-processor.js
+++ b/src/contentApi/request-processor.js
@@ -48,7 +48,8 @@ export const processRequest = async ({
       throw 'User does not have permissions';
     }
     let response;
-    if (url) {
+    const { identity } = (await insights.chrome.auth.getUser()) || {};
+    if (url && identity?.account_number) {
       /**
        * FEC interceptors were logging out users if the API returned 401 response.
        * That is not required behavior in this case. IF we get 401 we just hide the data.
@@ -59,7 +60,7 @@ export const processRequest = async ({
         data: JSON.stringify(args[0]),
       }).then((d) => d.json());
     }
-    if (typeof responseProcessor === 'function') {
+    if (typeof responseProcessor === 'function' && identity?.account_number) {
       response = await responseProcessor(response);
     }
     return {

--- a/src/utils/allPermissions.js
+++ b/src/utils/allPermissions.js
@@ -1,17 +1,21 @@
 let permissions = [];
 
 export const loadPermissions = async (retries = 5) => {
-  try {
-    if (retries > 0) {
-      const userPermissions = await window.insights.chrome.getUserPermissions();
-      permissions = userPermissions?.map(({ permission }) => permission) || [];
-    }
+  const { identity } = (await insights.chrome.auth.getUser()) || {};
+  if (identity?.account_number) {
+    try {
+      if (retries > 0) {
+        const userPermissions = await window.insights.chrome.getUserPermissions();
+        permissions =
+          userPermissions?.map(({ permission }) => permission) || [];
+      }
 
-    if (retries === 0) {
-      permissions = [];
+      if (retries === 0) {
+        permissions = [];
+      }
+    } catch {
+      await loadPermissions(retries - 1);
     }
-  } catch {
-    await loadPermissions(retries - 1);
   }
 };
 


### PR DESCRIPTION
There's an error when someone creates a new user account the Akamai will think that the user is DDOSing their service so they block the IP from accessing CRC. This PR prevents such issue by checking if account_number is defined (if undefined the user shouldn't really see anything because they have no real account attached to them).