### PR TITLE
Add auth to request processor.

### DIFF
--- a/src/contentApi/request-processor.js
+++ b/src/contentApi/request-processor.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import Cookies from 'js-cookie';
 
 import {
   hasPermissions as hasPermissionsEnhanced,
@@ -20,6 +21,8 @@ const enhancedFunctions = {
 
 const ALLOWED_API_METHODS = ['get', 'post'];
 
+let headers;
+
 export const processRequest = async ({
   method = 'get',
   args = [],
@@ -31,6 +34,14 @@ export const processRequest = async ({
   permissions,
   condition,
 }) => {
+  if (!headers) {
+    headers = {
+      Accept: 'application/json',
+      Authorization: `Bearer ${Cookies.get('cs_jwt')}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
   if (!ALLOWED_API_METHODS.includes(method)) {
     throw `Invalid request method ${method}. Expected one of ${ALLOWED_API_METHODS}`;
   }
@@ -48,6 +59,7 @@ export const processRequest = async ({
        */
       response = await fetch(url, {
         method,
+        headers,
         data: JSON.stringify(args[0]),
       }).then((d) => d.json());
     }


### PR DESCRIPTION
fixes #300

The problem with the previous solution was quite simple. When the headers object was created, it the user was not ready and the token did not exist and the cookie was sending `undefined` (file was loaded into browser memory pretty early). But moving the cookie get method into the actual function. Now we send the proper auth token to the API. Kafka still returns 401, but now it returns object from the kafka API so we are actually finally hitting it. This is a sample of the 404 response (which does not match our interceptor).

```jsx
{
  "kind": "Error",
  "id": "15",
  "href": "/api/managed-services-api/v1/errors/15",
  "code": "MGD-SERV-API-15",
  "reason": "Bearer token can't be verified"
}
```

Don't know if this is expected or not. Would be nice if we had some account which has actually access to some data to verify.