### PR TITLE
Add background color to Estate section

### DIFF
--- a/src/components/app-content-renderer/styles/panels.scss
+++ b/src/components/app-content-renderer/styles/panels.scss
@@ -27,6 +27,7 @@
   .ins-l-first-panel {
     color: var(--pf-global--Color--light-100);
     background: url(https://cloud.redhat.com/apps/frontend-assets/background-images/new-landing-page/estate-double_gradient.svg);
+    background-color: var(--pf-global--BackgroundColor--dark-100);
     background-size: cover !important;
     padding: var(--pf-global--spacer--xl) var(--pf-global--spacer--lg) var(--pf-global--spacer--lg) var(--pf-global--spacer--lg);
     overflow-x: auto;


### PR DESCRIPTION
Add background color in case loading of background image is delayed

Jira: https://issues.redhat.com/browse/RHCLOUD-13876

Old
<img width="532" alt="Screen Shot 2021-05-04 at 11 27 15 AM" src="https://user-images.githubusercontent.com/1287144/117028967-35273580-accc-11eb-9e78-8457297de9e3.png">

New
<img width="640" alt="Screen Shot 2021-05-04 at 11 29 35 AM" src="https://user-images.githubusercontent.com/1287144/117028916-26d91980-accc-11eb-9539-3c85c5cb548e.png">

<img width="666" alt="Screen Shot 2021-05-04 at 11 31 55 AM" src="https://user-images.githubusercontent.com/1287144/117029131-5e47c600-accc-11eb-910c-95c883d50f0e.png">

