### PR TITLE
Fix Estate skeleton styling for mobile

### DIFF
--- a/src/components/app-content-renderer/styles/panels.scss
+++ b/src/components/app-content-renderer/styles/panels.scss
@@ -113,6 +113,12 @@
               padding-right: var(--pf-global--spacer--sm);
             }
           }
+          .estate-count {
+            min-width: var(--pf-global--spacer--md); // sets min-width so that skeleton is visible
+          }
+          .estate-title {
+            min-width: var(--pf-global--spacer--3xl); // sets min-width so that skeleton is visible
+          }
         }
       }
     }


### PR DESCRIPTION
Sets a min-width on Estate count & title so that skeleton is obvious while loading in mobile layout

Jira: https://issues.redhat.com/browse/RHCLOUD-13875

Old
![Screen Shot 2021-05-05 at 10 46 31 AM](https://user-images.githubusercontent.com/1287144/117171507-ebf0e780-ad98-11eb-94fd-59a21fa11510.png)


New
![Screen Shot 2021-05-05 at 11 52 36 AM](https://user-images.githubusercontent.com/1287144/117171390-d1b70980-ad98-11eb-99a3-073078a30ab8.png)
