### PR TITLE
update react-core to 4.168.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "homepage": "https://github.com/RedHatInsights/landing-page-frontend#readme",
   "dependencies": {
     "@patternfly/patternfly": "^4.96.2",
-    "@patternfly/react-core": "^4.106.2",
+    "@patternfly/react-core": "^4.168.8",
     "@patternfly/react-icons": "^4.9.9",
     "@redhat-cloud-services/frontend-components": "^3.1.6",
     "@redhat-cloud-services/frontend-components-notifications": "^3.1.0",

--- a/src/__tests__/__snapshots__/NotFound.test.js.snap
+++ b/src/__tests__/__snapshots__/NotFound.test.js.snap
@@ -15,6 +15,9 @@ exports[`NotFound component should render correctly 1`] = `
         >
           <h1
             className="pf-c-title pf-m-3xl"
+            data-ouia-component-id="OUIA-Generated-Title-1"
+            data-ouia-component-type="PF4/Title"
+            data-ouia-safe={true}
           >
             404: We lost that page
           </h1>
@@ -265,6 +268,9 @@ exports[`NotFound component should render correctly 1`] = `
         >
           <h2
             className="pf-c-title pf-m-xl land-c-text__sorry"
+            data-ouia-component-id="OUIA-Generated-Title-2"
+            data-ouia-component-type="PF4/Title"
+            data-ouia-safe={true}
           >
             Let's find you a new one. Try a new search or return home.
           </h2>

--- a/src/routes/__tests__/__snapshots__/404.test.js.snap
+++ b/src/routes/__tests__/__snapshots__/404.test.js.snap
@@ -14,6 +14,9 @@ exports[`404 page should render correctly 1`] = `
       >
         <h1
           className="pf-c-title pf-m-3xl"
+          data-ouia-component-id="OUIA-Generated-Title-1"
+          data-ouia-component-type="PF4/Title"
+          data-ouia-safe={true}
         >
           404: We lost that page
         </h1>
@@ -264,6 +267,9 @@ exports[`404 page should render correctly 1`] = `
       >
         <h2
           className="pf-c-title pf-m-xl land-c-text__sorry"
+          data-ouia-component-id="OUIA-Generated-Title-2"
+          data-ouia-component-type="PF4/Title"
+          data-ouia-safe={true}
         >
           Let's find you a new one. Try a new search or return home.
         </h2>

--- a/src/routes/__tests__/__snapshots__/Logout.test.js.snap
+++ b/src/routes/__tests__/__snapshots__/Logout.test.js.snap
@@ -11,6 +11,9 @@ exports[`Logout component should render correctly 1`] = `
     >
       <h1
         className="pf-c-title pf-m-3xl"
+        data-ouia-component-id="OUIA-Generated-Title-1"
+        data-ouia-component-type="PF4/Title"
+        data-ouia-safe={true}
       >
         You have logged out.
       </h1>

--- a/src/routes/__tests__/__snapshots__/Maintenance.test.js.snap
+++ b/src/routes/__tests__/__snapshots__/Maintenance.test.js.snap
@@ -170,6 +170,9 @@ exports[`Maintenance page should render correctly 1`] = `
           >
             <h5
               className="pf-c-title pf-m-lg"
+              data-ouia-component-id="OUIA-Generated-Title-1"
+              data-ouia-component-type="PF4/Title"
+              data-ouia-safe={true}
             >
               Maintenance in progress
             </h5>


### PR DESCRIPTION
Fixes broken masthead styling

https://issues.redhat.com/browse/RHCLOUD-16946

Old
<img width="1368" alt="Screen Shot 2021-11-11 at 2 39 19 PM" src="https://user-images.githubusercontent.com/1287144/141358582-d5d3a8b4-5462-44ee-8ffc-3e2531c1681d.png">

New
<img width="1271" alt="Screen Shot 2021-11-11 at 2 19 57 PM" src="https://user-images.githubusercontent.com/1287144/141356186-f1c63220-f697-48f1-be56-74a4cb85d765.png">
