### PR TITLE
Use custom axios instance interceptors.

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -27,6 +27,7 @@ global.window.insights = {
         window.insights.chrome) ||
         {}),
       login: returnBlank,
+      getToken: () => Promise.resolve('blablatoken'),
       getUser: () =>
         new Promise((res) =>
           res({

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,6 @@ import { Switch, Route } from 'react-router-dom';
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { IntlProvider } from 'react-intl';
-import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import contentStore from './store/contentReducer';
 
 const Landing = lazy(() =>
@@ -41,19 +40,6 @@ const App = () => {
       .getUser()
       .then((user) => user && setIsOrgAdmin(user.identity.user.is_org_admin));
   }, []);
-
-  axiosInstance.interceptors.request.use(async (config) => {
-    await insights.chrome.auth.getUser();
-    const token = await insights.chrome.auth.getToken();
-    const updatedCfg = { ...config };
-    if (token) {
-      updatedCfg.headers = {
-        ...updatedCfg.headers,
-        Authorization: `Bearer ${token}`,
-      };
-    }
-    return updatedCfg;
-  });
 
   return (
     <IntlProvider locale="en">

--- a/src/contentApi/get-apps-data.js
+++ b/src/contentApi/get-apps-data.js
@@ -1,4 +1,3 @@
-import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import { getAnsibleDataSchema } from './ansible-api';
 import { getCostDataSchema } from './cost-api';
 import { getFifiDataSchema } from './fifi-api';
@@ -6,6 +5,7 @@ import { getPriorityDataSchema } from './priority-api';
 import { createRhelSchema } from './rhel';
 
 import { getManagedServicesDataSchema } from './managed-services-api';
+import axiosInstance from '../utils/axiosInstance';
 
 async function getSchema(url, section) {
   try {
@@ -32,19 +32,14 @@ async function getSchema(url, section) {
 }
 
 const getAppsData = async (env) => {
-  const showUHC = env === 'prod' || env === 'qaprodauth';
   const data = await Promise.all([
     getPriorityDataSchema(),
     getManagedServicesDataSchema(),
-    ...(showUHC
-      ? [
-          getSchema(
-            `https://api${
-              env === 'qaprodauth' ? '.stage' : ''
-            }.openshift.com/api/accounts_mgmt/v1/landing_page/self_service`
-          ),
-        ]
-      : []),
+    getSchema(
+      `https://api${
+        env === 'qaprodauth' ? '.stage' : ''
+      }.openshift.com/api/accounts_mgmt/v1/landing_page/self_service`
+    ),
     createRhelSchema(),
     getSchema(
       '/api/automation-hub/_ui/v1/landing-page/',

--- a/src/routes/__tests__/Landing.test.js
+++ b/src/routes/__tests__/Landing.test.js
@@ -8,7 +8,7 @@ import { mount } from 'enzyme';
 import { Modal, Title } from '@patternfly/react-core';
 import { ScalprumProvider } from '@scalprum/react-core';
 
-import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import axiosInstance from '../../utils/axiosInstance';
 
 import * as notifications from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
 
@@ -66,17 +66,14 @@ jest.mock('../../consts', () => {
   };
 });
 
-jest.mock(
-  '@redhat-cloud-services/frontend-components-utilities/interceptors',
-  () => {
-    return {
-      __esModule: true,
-      default: {
-        get: () => Promise.resolve({}),
-      },
-    };
-  }
-);
+jest.mock('../../utils/axiosInstance', () => {
+  return {
+    __esModule: true,
+    default: {
+      get: () => Promise.resolve({}),
+    },
+  };
+});
 
 const mockStore = configureMockStore();
 const store = mockStore({});

--- a/src/utils/axiosInstance.js
+++ b/src/utils/axiosInstance.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import {
+  authInterceptor,
+  responseDataInterceptor,
+  interceptor500,
+  errorInterceptor,
+} from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+
+const axiosInstance = axios.create();
+axiosInstance.interceptors.request.use(authInterceptor);
+axiosInstance.interceptors.response.use(responseDataInterceptor);
+axiosInstance.interceptors.request.use(async (config) => {
+  const token = await insights.chrome.auth.getToken();
+  const updatedCfg = { ...config };
+  if (token) {
+    updatedCfg.headers = {
+      ...updatedCfg.headers,
+      Authorization: `Bearer ${token}`,
+    };
+  }
+  return updatedCfg;
+});
+
+axiosInstance.interceptors.response.use(null, interceptor500);
+axiosInstance.interceptors.response.use(null, errorInterceptor);
+
+export default axiosInstance;


### PR DESCRIPTION
### Changes
- use custom axios instance interceptors

When using the default instance, the 401 interceptor is causing issues. If a landing page endpoint API returns a 401, we get stuck in an infinite loading loop, even if the chrome has authorized successfully. This was exposed by the openshift content that does don't support the stage environment. Even with the correct headers.