### PR TITLE
Use chrome's API instead of getting token from cookies

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -7,6 +7,9 @@ const { config: webpackConfig, plugins } = config({
   debug: true,
   https: true,
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
+  ...(process.env.INSIGHTS_CHROME && {
+    localChrome: process.env.INSIGHTS_CHROME,
+  }),
   ...(process.env.PROXY && {
     useProxy: true,
     env: 'stage-stable',

--- a/src/contentApi/request-processor.js
+++ b/src/contentApi/request-processor.js
@@ -1,5 +1,4 @@
 import get from 'lodash/get';
-import Cookies from 'js-cookie';
 
 import {
   hasPermissions as hasPermissionsEnhanced,
@@ -33,10 +32,11 @@ export const processRequest = async ({
   permissions,
   condition,
 }) => {
+  const token = await insights.chrome.auth.getToken();
   if (!headers) {
     headers = {
       Accept: 'application/json',
-      Authorization: `Bearer ${Cookies.get('cs_jwt')}`,
+      Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     };
   }


### PR DESCRIPTION
### Description

When we are fetching data from landing page we are also adding bearer token to each request. This token contains JWT token, however we are pulling this token from cookie, instead of calling chrome's API. This PR fixes such issue, by calling `insights.chrome.auth.getToken` and then using said token.