### PR TITLE
Remove temporary entitlements modal.

### DIFF
--- a/src/routes/Landing.js
+++ b/src/routes/Landing.js
@@ -8,7 +8,6 @@ import '../components/app-content-renderer/styles/panels.scss';
 import FirstPanel from '../components/app-content-renderer/first-panel';
 import SecondPanel from '../components/app-content-renderer/second-panel';
 import FooterTraditional from '../layout/FooterTraditional';
-import NotEntitledModal from '../components/not-entitled-modal/not-entitled-modal';
 
 const Landing = () => {
   return (
@@ -18,7 +17,6 @@ const Landing = () => {
           <FirstPanel />
           <SecondPanel />
           <FooterTraditional />
-          <NotEntitledModal />
         </Fragment>
       </SplitItem>
     </Split>


### PR DESCRIPTION
The chrome with entitlements modal has been deployed to prod. No need fo the component to be rendered on the landing page anymore.