### PR TITLE
RHCLOUD-23727: Run IQE UI tests as part of PR check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 export COMPONENT="landing-page-frontend"
 export IMAGE="quay.io/cloudservices/$COMPONENT"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace
@@ -15,6 +16,37 @@ set -ex
 # source is preferred to | bash -s in this case to avoid a subshell
 source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
 BUILD_RESULTS=$?
+
+echo "Taking a short nap"
+sleep 120
+
+# Ensure that we deploy the right component for testing
+export APP_NAME=rbac
+export COMPONENT="rbac"
+export COMPONENT_NAME="rbac"
+
+# Install bonfire
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh 
+
+source .cicd_bootstrap.sh
+
+set -x
+# Deploy to an ephemeral namespace for testing
+export GIT_COMMIT=master
+source $CICD_ROOT/deploy_ephemeral_env.sh
+
+set +x
+# Run some tests with ClowdJobInvocation
+IQE_PLUGINS="platform_ui"
+IQE_MARKER_EXPRESSION="smoke"
+IQE_FILTER_EXPRESSION=""
+IQE_ENV="ephemeral"
+IQE_SELENIUM="true"
+IQE_CJI_TIMEOUT="30m"
+DEPLOY_TIMEOUT="900"  # 15min
+DEPLOY_FRONTENDS="true"
+source $CICD_ROOT/cji_smoke_test.sh
 
 # Stubbed out for now
 mkdir -p $WORKSPACE/artifacts

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -46,7 +46,8 @@ export IQE_IMAGE_TAG="platform-ui"
 IQE_PLUGINS="platform_ui"
 IQE_MARKER_EXPRESSION="smoke"
 # Exclude progressive profile tests
-IQE_FILTER_EXPRESSION="not test_progressive"
+# Exclude APIdocs tests
+IQE_FILTER_EXPRESSION="not test_progressive and not test_apidocs"
 IQE_ENV="ephemeral"
 IQE_SELENIUM="true"
 IQE_CJI_TIMEOUT="30m"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -47,7 +47,7 @@ IQE_PLUGINS="platform_ui"
 IQE_MARKER_EXPRESSION="smoke"
 # Exclude progressive profile tests
 # Exclude APIdocs tests
-IQE_FILTER_EXPRESSION="not test_progressive and not test_apidocs"
+IQE_FILTER_EXPRESSION="not (test_progressive or test_apidocs)"
 IQE_ENV="ephemeral"
 IQE_SELENIUM="true"
 IQE_CJI_TIMEOUT="30m"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -40,7 +40,6 @@ export IMAGE_TAG=latest
 export DEPLOY_FRONTENDS=true
 source $CICD_ROOT/deploy_ephemeral_env.sh
 
-set +x
 # Run some tests with ClowdJobInvocation
 export IQE_IMAGE_TAG="platform-ui"
 IQE_PLUGINS="platform_ui"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -29,11 +29,12 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh
 source .cicd_bootstrap.sh
 
 echo "Taking a short nap"
-sleep 120
+sleep 60
 
 
 set -x
 # Deploy to an ephemeral namespace for testing
+export IMAGE="quay.io/cloudservices/rbac"
 export GIT_COMMIT=master
 source $CICD_ROOT/deploy_ephemeral_env.sh
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -36,7 +36,7 @@ set -x
 # Deploy to an ephemeral namespace for testing
 export IMAGE="quay.io/cloudservices/rbac"
 export GIT_COMMIT=master
-export IMAGE_TAG=master
+export IMAGE_TAG=latest
 export DEPLOY_FRONTENDS=true
 source $CICD_ROOT/deploy_ephemeral_env.sh
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -36,6 +36,7 @@ set -x
 # Deploy to an ephemeral namespace for testing
 export IMAGE="quay.io/cloudservices/rbac"
 export GIT_COMMIT=master
+export IMAGE_TAG=master
 source $CICD_ROOT/deploy_ephemeral_env.sh
 
 set +x

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -38,6 +38,7 @@ source $CICD_ROOT/deploy_ephemeral_env.sh
 
 set +x
 # Run some tests with ClowdJobInvocation
+export IMAGE="quay.io/cloudservices/iqe-tests:platform-ui"
 IQE_PLUGINS="platform_ui"
 IQE_MARKER_EXPRESSION="smoke"
 IQE_FILTER_EXPRESSION=""

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -45,7 +45,8 @@ set +x
 export IQE_IMAGE_TAG="platform-ui"
 IQE_PLUGINS="platform_ui"
 IQE_MARKER_EXPRESSION="smoke"
-IQE_FILTER_EXPRESSION=""
+# Exclude progressive profile tests
+IQE_FILTER_EXPRESSION="not test_progressive"
 IQE_ENV="ephemeral"
 IQE_SELENIUM="true"
 IQE_CJI_TIMEOUT="30m"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -17,14 +17,10 @@ set -ex
 source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
 BUILD_RESULTS=$?
 
-echo "Taking a short nap"
-sleep 120
-
 # Ensure that we deploy the right component for testing
 export APP_NAME=rbac
 export COMPONENT="rbac"
 export COMPONENT_NAME="rbac"
-export IMAGE="quay.io/cloudservices/rbac"
 
 # Install bonfire
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -28,6 +28,10 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh
 
 source .cicd_bootstrap.sh
 
+echo "Taking a short nap"
+sleep 120
+
+
 set -x
 # Deploy to an ephemeral namespace for testing
 export GIT_COMMIT=master

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -39,7 +39,7 @@ source $CICD_ROOT/deploy_ephemeral_env.sh
 
 set +x
 # Run some tests with ClowdJobInvocation
-export IMAGE="quay.io/cloudservices/iqe-tests:platform-ui"
+export IQE_IMAGE_TAG="platform-ui"
 IQE_PLUGINS="platform_ui"
 IQE_MARKER_EXPRESSION="smoke"
 IQE_FILTER_EXPRESSION=""

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -24,6 +24,7 @@ sleep 120
 export APP_NAME=rbac
 export COMPONENT="rbac"
 export COMPONENT_NAME="rbac"
+export IMAGE="quay.io/cloudservices/rbac"
 
 # Install bonfire
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -37,6 +37,7 @@ set -x
 export IMAGE="quay.io/cloudservices/rbac"
 export GIT_COMMIT=master
 export IMAGE_TAG=master
+export DEPLOY_FRONTENDS=true
 source $CICD_ROOT/deploy_ephemeral_env.sh
 
 set +x


### PR DESCRIPTION
Run IQE smoke tests in PR checks. Excludes progressive profile tests and APIDocs tests. Uses an RBAC deployment for testing; in the future it could hypothetically use a component-specifc deployment of the landing-page.