### PR TITLE
Use proper document title

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,8 @@ const App = () => {
   const [isOrgAdmin, setIsOrgAdmin] = useState();
   const chrome = useChrome();
 
+  chrome?.updateDocumentTitle?.('Hybrid Cloud Console Home', false);
+
   useEffect(() => {
     getRegistry().register({ contentStore });
     chrome.auth


### PR DESCRIPTION
### Description

We want to show proper doc title when user lands on landing page. We also don't want to show the content behind `|`.

### JIRA

RHCLOUD-25356