### PR TITLE
RHCLOUD-29161 Deploy virtual-assistant on the landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@testing-library/react": "^12.1.5",
         "@testing-library/react-hooks": "^7.0.2",
         "@testing-library/user-event": "^14.4.3",
+        "@unleash/proxy-client-react": "^3.6.0",
         "classnames": "^2.3.2",
         "lodash": "^4.17.21",
         "prop-types": "^15.8.1",
@@ -4852,12 +4853,11 @@
       }
     },
     "node_modules/@unleash/proxy-client-react": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-3.5.1.tgz",
-      "integrity": "sha512-eN9rsLrHYyGQt+Ok0+LA/1+TkTVY4m2DJcxgfKEUv/AzetxoE7Nq/rlRo8B71vC+wjsYI6qJ/OKwbopoUZiY1A==",
-      "peer": true,
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-3.6.0.tgz",
+      "integrity": "sha512-maQ3PYdBWUpIraD9z/2C8oVoCAS/EryV0WT4HiZQWxzrwvrZ+XHQJw1sImzRdWlGMvl1qJcgdEoxXhNSuYIrEQ==",
       "peerDependencies": {
-        "unleash-proxy-client": "^2.4.2"
+        "unleash-proxy-client": "^2.5.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -19189,9 +19189,9 @@
       }
     },
     "node_modules/unleash-proxy-client": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-2.4.2.tgz",
-      "integrity": "sha512-fkVne/51EsllGFuNFbEidSjB7uErFOI1GJgv9RyXy3LWrBSxIdH/P2lE/keKeH0SrU89/Wufamfk5jLogJTisQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-2.5.0.tgz",
+      "integrity": "sha512-GWYLcQDW2UVhqAVwZX7jNzD6Lp96UJXEi66r9MiDd/C3Xw7rbTdFziNJAhEZpLNqR7j75+TfZaEYMCMy/k778g==",
       "peer": true,
       "dependencies": {
         "tiny-emitter": "^2.1.0",
@@ -23926,10 +23926,9 @@
       }
     },
     "@unleash/proxy-client-react": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-3.5.1.tgz",
-      "integrity": "sha512-eN9rsLrHYyGQt+Ok0+LA/1+TkTVY4m2DJcxgfKEUv/AzetxoE7Nq/rlRo8B71vC+wjsYI6qJ/OKwbopoUZiY1A==",
-      "peer": true,
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-3.6.0.tgz",
+      "integrity": "sha512-maQ3PYdBWUpIraD9z/2C8oVoCAS/EryV0WT4HiZQWxzrwvrZ+XHQJw1sImzRdWlGMvl1qJcgdEoxXhNSuYIrEQ==",
       "requires": {}
     },
     "@webassemblyjs/ast": {
@@ -34689,9 +34688,9 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "unleash-proxy-client": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-2.4.2.tgz",
-      "integrity": "sha512-fkVne/51EsllGFuNFbEidSjB7uErFOI1GJgv9RyXy3LWrBSxIdH/P2lE/keKeH0SrU89/Wufamfk5jLogJTisQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-2.5.0.tgz",
+      "integrity": "sha512-GWYLcQDW2UVhqAVwZX7jNzD6Lp96UJXEi66r9MiDd/C3Xw7rbTdFziNJAhEZpLNqR7j75+TfZaEYMCMy/k778g==",
       "peer": true,
       "requires": {
         "tiny-emitter": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "transformIgnorePatterns": [
       "/node_modules/(?!@redhat-cloud-services|@openshift|lodash-es|@scalprum)"
     ],
-    "testMatch": ["**/?(*.)+(test).ts?(x)", "**/?(*.)+(test).js?(x)"]
+    "testMatch": [
+      "**/?(*.)+(test).ts?(x)",
+      "**/?(*.)+(test).js?(x)"
+    ]
   },
   "scripts": {
     "test": "jest --passWithNoTests",
@@ -80,6 +83,7 @@
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^7.0.2",
     "@testing-library/user-event": "^14.4.3",
+    "@unleash/proxy-client-react": "^3.6.0",
     "classnames": "^2.3.2",
     "lodash": "^4.17.21",
     "prop-types": "^15.8.1",

--- a/src/__mocks__/@redhat-cloud-services/frontend-components/useChrome.js
+++ b/src/__mocks__/@redhat-cloud-services/frontend-components/useChrome.js
@@ -4,4 +4,4 @@ const useChrome = () => ({
   visibilityFunctions: { apiRequest: () => Promise.resolve(true) },
 });
 
-module.exports.useChrome = useChrome;
+module.exports = useChrome;

--- a/src/components/app-content-renderer/virtual-assistant.js
+++ b/src/components/app-content-renderer/virtual-assistant.js
@@ -1,0 +1,27 @@
+import { useFlag } from '@unleash/proxy-client-react';
+import React from 'react';
+import { ScalprumComponent } from '@scalprum/react-core';
+
+import './virtual-assistant.scss';
+import useChrome from "@redhat-cloud-services/frontend-components/useChrome";
+
+function VirtualAssistant() {
+    const showVirtualAssistant = useFlag('platform.landing-page.virtual-assistant');
+    const chrome = useChrome();
+
+    if (!chrome.isBeta || !showVirtualAssistant) {
+        return null;
+    }
+
+    return (
+        <div className="virtualAssistant astro__landing-page">
+            <ScalprumComponent
+                scope="virtualAssistant"
+                module="./AstroVirtualAssistant"
+                fallback={null}
+            />
+        </div>
+    );
+}
+
+export default VirtualAssistant;

--- a/src/components/app-content-renderer/virtual-assistant.js
+++ b/src/components/app-content-renderer/virtual-assistant.js
@@ -12,7 +12,7 @@ function VirtualAssistant() {
   const chrome = useChrome();
 
   // Disable it for prod, any stable environment or if the feature flag is off
-  if (chrome.isProd() || !chrome.isBeta || !showVirtualAssistant) {
+  if (chrome.isProd() || !chrome.isBeta() || !showVirtualAssistant) {
     return null;
   }
 
@@ -22,6 +22,7 @@ function VirtualAssistant() {
         scope="virtualAssistant"
         module="./AstroVirtualAssistant"
         fallback={null}
+        ErrorComponent={null}
       />
     </div>
   );

--- a/src/components/app-content-renderer/virtual-assistant.js
+++ b/src/components/app-content-renderer/virtual-assistant.js
@@ -12,7 +12,7 @@ function VirtualAssistant() {
   const chrome = useChrome();
 
   // Disable it for prod, any stable environment or if the feature flag is off
-  if (chrome.isProd() || !chrome.isBeta() || !showVirtualAssistant) {
+  if (!showVirtualAssistant || (chrome.isProd() && !chrome.isBeta())) {
     return null;
   }
 

--- a/src/components/app-content-renderer/virtual-assistant.js
+++ b/src/components/app-content-renderer/virtual-assistant.js
@@ -3,25 +3,28 @@ import React from 'react';
 import { ScalprumComponent } from '@scalprum/react-core';
 
 import './virtual-assistant.scss';
-import useChrome from "@redhat-cloud-services/frontend-components/useChrome";
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 function VirtualAssistant() {
-    const showVirtualAssistant = useFlag('platform.landing-page.virtual-assistant');
-    const chrome = useChrome();
+  const showVirtualAssistant = useFlag(
+    'platform.landing-page.virtual-assistant'
+  );
+  const chrome = useChrome();
 
-    if (!chrome.isBeta || !showVirtualAssistant) {
-        return null;
-    }
+  // Disable it for prod, any stable environment or if the feature flag is off
+  if (chrome.isProd() || !chrome.isBeta || !showVirtualAssistant) {
+    return null;
+  }
 
-    return (
-        <div className="virtualAssistant astro__landing-page">
-            <ScalprumComponent
-                scope="virtualAssistant"
-                module="./AstroVirtualAssistant"
-                fallback={null}
-            />
-        </div>
-    );
+  return (
+    <div className="virtualAssistant astro__landing-page">
+      <ScalprumComponent
+        scope="virtualAssistant"
+        module="./AstroVirtualAssistant"
+        fallback={null}
+      />
+    </div>
+  );
 }
 
 export default VirtualAssistant;

--- a/src/components/app-content-renderer/virtual-assistant.js
+++ b/src/components/app-content-renderer/virtual-assistant.js
@@ -1,5 +1,5 @@
 import { useFlag } from '@unleash/proxy-client-react';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { ScalprumComponent } from '@scalprum/react-core';
 
 import './virtual-assistant.scss';
@@ -22,7 +22,7 @@ function VirtualAssistant() {
         scope="virtualAssistant"
         module="./AstroVirtualAssistant"
         fallback={null}
-        ErrorComponent={null}
+        ErrorComponent={<Fragment />}
       />
     </div>
   );

--- a/src/components/app-content-renderer/virtual-assistant.scss
+++ b/src/components/app-content-renderer/virtual-assistant.scss
@@ -1,0 +1,11 @@
+.astro__landing-page {
+  position: fixed;
+  bottom: 5px;
+  right: 5px;
+  z-index: 1000;
+
+  .astro-l-stack {
+    padding-right: 15px;
+    padding-bottom: 8px;
+  }
+}

--- a/src/routes/Landing.js
+++ b/src/routes/Landing.js
@@ -4,11 +4,13 @@ import '../components/app-content-renderer/styles/panels.scss';
 
 import FirstPanel from '../components/app-content-renderer/first-panel';
 import SecondPanel from '../components/app-content-renderer/second-panel';
+import VirtualAssistant from "../components/app-content-renderer/virtual-assistant";
 
 const Landing = () => {
   return (
     <div className="land-c-page-content pf-u-display-flex pf-u-flex-direction-column">
       <Fragment>
+        <VirtualAssistant />
         <FirstPanel />
         <SecondPanel />
       </Fragment>

--- a/src/routes/Landing.js
+++ b/src/routes/Landing.js
@@ -4,7 +4,7 @@ import '../components/app-content-renderer/styles/panels.scss';
 
 import FirstPanel from '../components/app-content-renderer/first-panel';
 import SecondPanel from '../components/app-content-renderer/second-panel';
-import VirtualAssistant from "../components/app-content-renderer/virtual-assistant";
+import VirtualAssistant from '../components/app-content-renderer/virtual-assistant';
 
 const Landing = () => {
   return (


### PR DESCRIPTION
 - Behind feature flag "platform.landing-page.virtual-assistant"
 - Only on beta/preview

It's currently behind pendo's lightbulb:

![image](https://github.com/RedHatInsights/landing-page-frontend/assets/3845764/f914d421-befa-43b6-a968-437883222932)

Once that's removed, it should look like this:

![image](https://github.com/RedHatInsights/landing-page-frontend/assets/3845764/595baa42-f911-41ae-9bde-5de8396f7ac2)

And it starts hidden. similar to pendo's lightbulb

![image](https://github.com/RedHatInsights/landing-page-frontend/assets/3845764/cbd2ac6f-65eb-489e-b880-afe0f6a25daa)

