### PR TITLE
Add recently visited widget

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -11,6 +11,10 @@ module.exports = {
   moduleFederation: {
     exposes: {
       './RootApp': path.resolve(__dirname, './src/moduleEntries/AppEntry.tsx'),
+      './RecentlyVisited': path.resolve(
+        __dirname,
+        'src/components/widgets/recently-visited.tsx'
+      ),
     },
     exclude: ['react-router-dom'],
     shared: [{ 'react-router-dom': { singleton: true, version: '*' } }],

--- a/src/components/widgets/recently-visited.scss
+++ b/src/components/widgets/recently-visited.scss
@@ -1,0 +1,3 @@
+.widget-recently-visited {
+    column-width: 300px;
+}

--- a/src/components/widgets/recently-visited.tsx
+++ b/src/components/widgets/recently-visited.tsx
@@ -10,7 +10,7 @@ import React, { Fragment } from 'react';
 import { useLastVisited } from '@redhat-cloud-services/chrome';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { Link } from 'react-router-dom';
-import './RecentlyVisited.scss';
+import './recently-visited.scss';
 
 const LinkWrapper = ({
   pathname,

--- a/src/components/widgets/recently-visited.tsx
+++ b/src/components/widgets/recently-visited.tsx
@@ -1,0 +1,47 @@
+import {
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core/dist/dynamic/components/Text';
+
+import { Gallery } from '@patternfly/react-core/dist/dynamic/layouts/Gallery';
+
+import React, { Fragment } from 'react';
+import { useLastVisited } from '@redhat-cloud-services/chrome';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { Link } from 'react-router-dom';
+import './RecentlyVisited.scss';
+
+const LinkWrapper = ({
+  pathname,
+  title,
+}: {
+  pathname: string;
+  title: string;
+}) => {
+  const { updateDocumentTitle } = useChrome();
+  return (
+    <Link onClick={() => updateDocumentTitle(title)} to={pathname}>
+      {title}
+    </Link>
+  );
+};
+
+const RecentlyVisited = () => {
+  const lastVisited = useLastVisited();
+  const lastVisitedData = lastVisited.slice(0, 10);
+  return (
+    <Gallery hasGutter className="widget-recently-visited pf-v5-u-m-lg">
+      {lastVisitedData.map(({ bundle, pathname, title }, index) => (
+        <Fragment key={index}>
+          <TextContent>
+            <LinkWrapper title={title} pathname={pathname} />
+            <Text component={TextVariants.small}>{bundle}</Text>
+          </TextContent>
+        </Fragment>
+      ))}
+    </Gallery>
+  );
+};
+
+export default RecentlyVisited;

--- a/src/components/widgets/recently-visited.tsx
+++ b/src/components/widgets/recently-visited.tsx
@@ -31,7 +31,7 @@ const RecentlyVisited = () => {
   const lastVisited = useLastVisited();
   const lastVisitedData = lastVisited.slice(0, 10);
   return (
-    <Gallery hasGutter className="widget-recently-visited pf-v5-u-m-lg">
+    <Gallery hasGutter className="widget-recently-visited pf-v5-u-m-md">
       {lastVisitedData.map(({ bundle, pathname, title }, index) => (
         <Fragment key={index}>
           <TextContent>


### PR DESCRIPTION
### Add 'Recently visited' widget
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUD-XXXXXX link (if proposed change involves tracked issue or story) -->
Adds 'Recently visited' widget for the new widgetized landing page.

[RHCLOUD-31028](https://issues.redhat.com/browse/RHCLOUD-31028)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [X] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##