### PR TITLE
RHCLOUD-31538 - Updates to explore widget

### DIFF
--- a/src/components/widgets/explore-capabilities.scss
+++ b/src/components/widgets/explore-capabilities.scss
@@ -3,9 +3,15 @@
       min-width: 300px;
       width: 300;
     }
+    .pf-v5-c-drawer__body {
+      img {
+        width: 60px;
+        max-width: 60px;
+      }
+    }
     .pf-v5-c-simple-list {
-      --pf-v5-c-simple-list__item-link--PaddingBottom: 8px;
-      --pf-v5-c-simple-list__item-link--PaddingTop: 8px;
+      --pf-v5-c-simple-list__item-link--PaddingBottom: 5px;
+      --pf-v5-c-simple-list__item-link--PaddingTop: 5.5px;
       --pf-v5-c-simple-list__item-link--m-current--FontWeight: var(--pf-v5-global--FontWeight--bold);
     }
     .pf-v5-c-simple-list__list {

--- a/src/components/widgets/explore-capabilities.tsx
+++ b/src/components/widgets/explore-capabilities.tsx
@@ -118,7 +118,7 @@ export const ExploreCapabilities: React.FunctionComponent = () => {
                   {drawerData[activeItem].body}
                 </Text>
                 <Button
-                  size="sm"
+                  size="lg"
                   component="a"
                   href={drawerData[activeItem].url}
                   target="_blank"

--- a/src/components/widgets/explore-capabilities.tsx
+++ b/src/components/widgets/explore-capabilities.tsx
@@ -9,8 +9,11 @@ import { SimpleList } from '@patternfly/react-core/dist/dynamic/components/Simpl
 import { SimpleListItem } from '@patternfly/react-core/dist/dynamic/components/SimpleList';
 import { Split } from '@patternfly/react-core/dist/dynamic/layouts/Split';
 import { SplitItem } from '@patternfly/react-core/dist/dynamic/layouts/Split';
-import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
 import './explore-capabilities.scss';
+import {
+  Text,
+  TextContent,
+} from '@patternfly/react-core/dist/dynamic/components/Text';
 
 export const ExploreCapabilities: React.FunctionComponent = () => {
   const [activeItem, setActiveItem] = React.useState(0);
@@ -63,10 +66,32 @@ export const ExploreCapabilities: React.FunctionComponent = () => {
     },
     {
       id: 'ex-toggle6',
+      name: 'Convert your CentOS systems to RHEL',
+      img: '/apps/frontend-assets/console-landing/widget-explore/Explore_CentOS-to-RHEL.svg',
+      title: 'Convert your CentOS systems to Red Hat Enterprise Linux (RHEL)',
+      body: (
+        <span>
+          On June 30, 2024, CentOS Linux 7 will reach End of Life (EOL), and
+          those systems will stop receiving updates, security pathes, and new
+          featues.
+          <br></br>
+          Red Hat can help.{' '}
+          <a href="https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/centos-migration">
+            Learn more
+          </a>{' '}
+          about migrating your CentOS Linux systems to RHEL, whether on-premise
+          or in the cloud.
+        </span>
+      ),
+      buttonName: 'Run a pre-conversion analysis',
+      url: 'https://console.redhat.com/insights/tasks?quickstart=insights-tasks-pre-conversion#SIDs=&tags=',
+    },
+    {
+      id: 'ex-toggle7',
       name: 'Configure your console',
       img: '/apps/frontend-assets/console-landing/widget-explore/Explore_configure.svg',
       title: 'Customize your notification settings',
-      body: 'Opt-in and out of receiving notifications for your console services.',
+      body: 'With Notification Preferences, opt-in and out of receiving notifications.',
       buttonName: 'Configure settings',
       url: 'https://console.redhat.com/settings/notifications',
     },
@@ -82,20 +107,26 @@ export const ExploreCapabilities: React.FunctionComponent = () => {
         <DrawerPanelBody>
           <Split>
             <SplitItem isFilled>
-              <Title className="pf-v5-u-mb-sm" headingLevel="h2" size="xl">
-                {drawerData[activeItem].title}
-              </Title>
-              <p className="pf-v5-u-mb-sm">{drawerData[activeItem].body}</p>
-              <Button
-                variant="danger"
-                size="lg"
-                component="a"
-                href={drawerData[activeItem].url}
-                target="_blank"
-                className="pf-v5-u-mb-sm"
-              >
-                {drawerData[activeItem].buttonName}
-              </Button>
+              <TextContent>
+                <Text component="h2" className="pf-v5-u-mb-sm">
+                  {drawerData[activeItem].title}
+                </Text>
+                <Text
+                  component="p"
+                  className="pf-v5-u-font-size-md pf-v5-u-mb-sm"
+                >
+                  {drawerData[activeItem].body}
+                </Text>
+                <Button
+                  size="sm"
+                  component="a"
+                  href={drawerData[activeItem].url}
+                  target="_blank"
+                  className="pf-m-danger pf-v5-u-mb-sm"
+                >
+                  {drawerData[activeItem].buttonName}
+                </Button>
+              </TextContent>
             </SplitItem>
             <SplitItem className="pf-v5-u-pl-sm">
               <img src={drawerData[activeItem].img} />
@@ -124,6 +155,9 @@ export const ExploreCapabilities: React.FunctionComponent = () => {
         Connect to your subscriptions
       </SimpleListItem>
       <SimpleListItem onClick={() => setActiveItem(5)}>
+        Convert your CentOS systems to RHEL
+      </SimpleListItem>
+      <SimpleListItem onClick={() => setActiveItem(6)}>
         Configure your console
       </SimpleListItem>
     </SimpleList>

--- a/src/components/widgets/explore-capabilities.tsx
+++ b/src/components/widgets/explore-capabilities.tsx
@@ -91,7 +91,7 @@ export const ExploreCapabilities: React.FunctionComponent = () => {
       name: 'Configure your console',
       img: '/apps/frontend-assets/console-landing/widget-explore/Explore_configure.svg',
       title: 'Customize your notification settings',
-      body: 'With Notification Preferences, opt-in and out of receiving notifications.',
+      body: 'Opt-in and out of receiving notifications for your console services.',
       buttonName: 'Configure settings',
       url: 'https://console.redhat.com/settings/notifications',
     },


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUD-XXXXXX link (if proposed change involves tracked issue or story) -->
Add CentOS listing + details
Change button to CTA styled button, color red, sz lg
Fix imgs

[RHCLOUD-31538](https://issues.redhat.com/browse/RHCLOUD-31538)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:

![Screenshot 2024-03-20 at 2 36 40 PM](https://github.com/RedHatInsights/landing-page-frontend/assets/86322239/90b332e7-a767-4e88-8d72-e7b73f261ba2)

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##