### PR TITLE
RHCLOUD-31621: Use default export for widgets (named exports not yet supported)

### DIFF
--- a/src/components/widgets/ansible-widget.tsx
+++ b/src/components/widgets/ansible-widget.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SimpleServiceWidget } from './simple-service-widget';
 
-export const AnsibleWidget: React.FunctionComponent = () => {
+const AnsibleWidget: React.FunctionComponent = () => {
   return (
     <>
       <SimpleServiceWidget
@@ -13,3 +13,5 @@ export const AnsibleWidget: React.FunctionComponent = () => {
     </>
   );
 };
+
+export default AnsibleWidget;

--- a/src/components/widgets/edge-widget.tsx
+++ b/src/components/widgets/edge-widget.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SimpleServiceWidget } from './simple-service-widget';
 
-export const EdgeWidget: React.FunctionComponent = () => {
+const EdgeWidget: React.FunctionComponent = () => {
   return (
     <>
       <SimpleServiceWidget
@@ -13,3 +13,5 @@ export const EdgeWidget: React.FunctionComponent = () => {
     </>
   );
 };
+
+export default EdgeWidget;

--- a/src/components/widgets/explore-capabilities.tsx
+++ b/src/components/widgets/explore-capabilities.tsx
@@ -15,7 +15,7 @@ import {
   TextContent,
 } from '@patternfly/react-core/dist/dynamic/components/Text';
 
-export const ExploreCapabilities: React.FunctionComponent = () => {
+const ExploreCapabilities: React.FunctionComponent = () => {
   const [activeItem, setActiveItem] = React.useState(0);
 
   const drawerData = [
@@ -173,3 +173,5 @@ export const ExploreCapabilities: React.FunctionComponent = () => {
     </React.Fragment>
   );
 };
+
+export default ExploreCapabilities;

--- a/src/components/widgets/openshift-widget.tsx
+++ b/src/components/widgets/openshift-widget.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SimpleServiceWidget } from './simple-service-widget';
 
-export const OpenShiftWidget: React.FunctionComponent = () => {
+const OpenShiftWidget: React.FunctionComponent = () => {
   return (
     <>
       <SimpleServiceWidget
@@ -13,3 +13,5 @@ export const OpenShiftWidget: React.FunctionComponent = () => {
     </>
   );
 };
+
+export default OpenShiftWidget;

--- a/src/components/widgets/rhel-widget.tsx
+++ b/src/components/widgets/rhel-widget.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SimpleServiceWidget } from './simple-service-widget';
 
-export const RhelWidget: React.FunctionComponent = () => {
+const RhelWidget: React.FunctionComponent = () => {
   return (
     <>
       <SimpleServiceWidget
@@ -13,3 +13,5 @@ export const RhelWidget: React.FunctionComponent = () => {
     </>
   );
 };
+
+export default RhelWidget;


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUD-XXXXXX link (if proposed change involves tracked issue or story) -->
Update the export of widgets to use default export as named exports are not _yet_ supported by widget-layout. 

[RHCLOUD-31621](https://issues.redhat.com/browse/RHCLOUD-31621)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![image](https://github.com/RedHatInsights/landing-page-frontend/assets/21317056/5e097e12-9bc6-439c-907f-52d89f83b9ba)


#### After:
TBD

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##