### PR TITLE
Add feature flag to enable widgets on prod preview env

### DIFF
--- a/src/routes/Landing.tsx
+++ b/src/routes/Landing.tsx
@@ -8,6 +8,8 @@ import SecondPanel from '../components/app-content-renderer/second-panel';
 import VirtualAssistant from '../components/app-content-renderer/virtual-assistant';
 import { useLoadModule } from '@scalprum/react-core';
 
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+
 const getWidgetLayoutLandingPage = () => {
   const scope = 'widgetLayout';
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -23,9 +25,10 @@ const getWidgetLayoutLandingPage = () => {
 };
 
 const Landing = () => {
-  const widgetLayoutLandingPageEnabled = useFlag(
-    'platform.landing-page.widgetization'
-  );
+  const { isBeta } = useChrome();
+  const widgetLayoutLandingPageEnabled =
+    (isBeta() && useFlag('platform.landing-page.widgetization')) ||
+    (!isBeta() && useFlag('platform.landing-page.widgetization-stable'));
   return (
     <div className="land-c-page-content pf-v5-u-display-flex pf-v5-u-flex-direction-column">
       <Fragment>


### PR DESCRIPTION
### Description

Check if feature platform.landing-page.widgetization is enabled on prod preview or non prod environment. And if so, show the widget layout.

[RHCLOUD-31835](https://issues.redhat.com/browse/RHCLOUD-31835)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
