### PR TITLE
RHCLOUD-31670: Update widget layout fed mod dependency to new API format

### DIFF
--- a/src/routes/Landing.tsx
+++ b/src/routes/Landing.tsx
@@ -7,41 +7,19 @@ import FirstPanel from '../components/app-content-renderer/first-panel';
 import SecondPanel from '../components/app-content-renderer/second-panel';
 import VirtualAssistant from '../components/app-content-renderer/virtual-assistant';
 import { useLoadModule } from '@scalprum/react-core';
-import { PageSection } from '@patternfly/react-core/dist/dynamic/components/Page';
 
 const getWidgetLayoutLandingPage = () => {
   const scope = 'widgetLayout';
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  const [{ default: GridLayout }] = useLoadModule(
+  const [{ default: WidgetLayout }] = useLoadModule(
     { scope, module: './WidgetLayout' },
     {}
   );
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const [{ default: AddWidgetDrawer }] = useLoadModule(
-    { scope, module: './WidgetDrawer' },
-    {}
-  );
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const [{ default: Header }] = useLoadModule(
-    { scope, module: './WidgetHeader' },
-    {}
-  );
-  if (!GridLayout || !AddWidgetDrawer || !Header) {
+  if (!WidgetLayout) {
     return <></>;
   }
-  return (
-    <>
-      <Header />
-      <AddWidgetDrawer dismissible={false}>
-        <PageSection>
-          <GridLayout isLayoutLocked={false} />
-        </PageSection>
-      </AddWidgetDrawer>
-    </>
-  );
+  return <WidgetLayout isLayoutLocked={false} layoutType={'landingPage'} />;
 };
 
 const Landing = () => {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Before we release I'd like to update the federated module API signature of widget layout to be more in line with what we do in learning resources.

We will also need a corresponding change in widget-layout: https://github.com/RedHatInsights/widget-layout/pull/51

See https://issues.redhat.com/browse/RHCLOUD-31670

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Consumers can now specify which layoutType to use - in this example I passed in `fooBar` to confirm it's working as expected:
![Screenshot 2024-04-09 at 11 52 45 PM](https://github.com/RedHatInsights/landing-page-frontend/assets/21317056/bf033a58-2748-4026-9314-abee4485cb16)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
