### PR TITLE
Automated test to remove all widgets and confirm "empty dashboard" message

### DIFF
--- a/cypress/e2e/widgets-landing.cy.ts
+++ b/cypress/e2e/widgets-landing.cy.ts
@@ -1,0 +1,47 @@
+function resetToDefaultLayout() {
+  cy.get('button')
+    .contains('Reset to default')
+    .click()
+    .get('#warning-modal-check')
+    .click()
+    .get("button[data-ouia-component-id='primary-confirm-button']")
+    .click();
+}
+
+describe('Widget Landing Page', () => {
+  it('closes all the widgets', () => {
+    cy.login();
+    cy.visit('/');
+
+    // Reset layout to the default
+    resetToDefaultLayout();
+    
+    // Ensure that widgets are open and displayed (Number of items in grid expected to be numDefaultWidgets)
+    const numDefaultWidgets = 9;
+    cy.get(
+      '.widgetLayout > section > div > .react-grid-layout > .react-grid-item'
+    )
+      .its('length')
+      .should('be.eq', numDefaultWidgets)
+      .wait(1500);
+
+    const cardActionsSelector =
+      '.widgetLayout > section > div > .react-grid-layout > .react-grid-item > div > .pf-v5-c-card__header > .pf-v5-c-card__actions > div > button';
+    
+    // Close all the widgets
+    for (let i = 0; i < numDefaultWidgets; i++) {
+      cy.get(cardActionsSelector)
+        .first()
+        .click()
+        .get('body > div.pf-v5-c-menu > div > ul > li:nth-child(4) > button')
+        .click()
+        .wait(1500);
+    }
+
+    // Confirm that the "empty" message is displayed
+    cy.get('h2').contains('No dashboard content');
+
+    // Reset to default layout
+    resetToDefaultLayout();
+  });
+});

--- a/cypress/e2e/widgets-landing.cy.ts
+++ b/cypress/e2e/widgets-landing.cy.ts
@@ -15,7 +15,7 @@ describe('Widget Landing Page', () => {
 
     // Reset layout to the default
     resetToDefaultLayout();
-    
+
     // Ensure that widgets are open and displayed (Number of items in grid expected to be numDefaultWidgets)
     const numDefaultWidgets = 9;
     cy.get(
@@ -27,7 +27,7 @@ describe('Widget Landing Page', () => {
 
     const cardActionsSelector =
       '.widgetLayout > section > div > .react-grid-layout > .react-grid-item > div > .pf-v5-c-card__header > .pf-v5-c-card__actions > div > button';
-    
+
     // Close all the widgets
     for (let i = 0; i < numDefaultWidgets; i++) {
       cy.get(cardActionsSelector)


### PR DESCRIPTION
### Description

Adds a Cypress test to remove all the widgets from the dashboard and then confirm the presence of the "dashboard empty" message that should appear. Note: We still need to decide the source file in which the Widget-related tests should live.

[RHCLOUD-32154](https://issues.redhat.com/browse/RHCLOUD-32154)

---

### Screenshots

#### Before:
N/A

#### After:
N/A

---

### Checklist ☑️
- [x] PR only fixes one issue or story
- [x] Change reviewed for extraneous code
- [ ] UI best practices adhered to
- [x] Commits squashed and meaningfully named
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
