### PR TITLE
Test that widgets can be moved around

### DIFF
--- a/cypress/e2e/widgets-landing.cy.ts
+++ b/cypress/e2e/widgets-landing.cy.ts
@@ -1,3 +1,5 @@
+import '@4tw/cypress-drag-drop';
+
 function resetToDefaultLayout() {
   cy.get('button')
     .contains('Reset to default')
@@ -7,6 +9,48 @@ function resetToDefaultLayout() {
     .get("button[data-ouia-component-id='primary-confirm-button']")
     .click();
 }
+
+const getLayout = () => {
+  return cy
+    .getCookie('cs_jwt')
+    .should('exist')
+    .then((token) => {
+      if (!token || !token.value) {
+        throw new Error('JWT cookie not found.');
+      }
+      return cy
+        .request({
+          url: 'https://stage.foo.redhat.com:1337/api/chrome-service/v1/dashboard-templates?dashboard=landingPage',
+          headers: {
+            Authorization: `Bearer ${token.value}`,
+          },
+          failOnStatusCode: false,
+        })
+        .then((response) => {
+          if (response.body && response.body.data) {
+            const defaultLayout = response.body.data.find(
+              (layout) => layout.default === true
+            );
+            if (defaultLayout) {
+              return defaultLayout.templateConfig;
+            } else {
+              throw new Error('Default layout not found in the response data.');
+            }
+          } else {
+            throw new Error('Response does not contain the "data" property.');
+          }
+        });
+    });
+};
+
+const moveWidget = (sourceIndex: number, targetIndex: number) => {
+  cy.get('.drag-handle')
+    .eq(sourceIndex)
+    .then((source) => {
+      const targetSelector = `.drag-handle:eq(${targetIndex})`;
+      cy.wrap(source).drag(targetSelector);
+    });
+};
 
 describe('Widget Landing Page', () => {
   it('closes all the widgets', () => {
@@ -43,5 +87,39 @@ describe('Widget Landing Page', () => {
 
     // Reset to default layout
     resetToDefaultLayout();
+  });
+
+  describe('Widget Layout', () => {
+    beforeEach(() => {
+      cy.login();
+      cy.visit('/');
+      cy.viewport(1280, 2000);
+      cy.get('.react-grid-item').should('be.visible');
+    });
+
+    it('widgets can be dragged and dropped', () => {
+      cy.intercept(
+        'GET',
+        '**/api/chrome-service/v1/dashboard-templates?dashboard=landingPage'
+      ).as('resetLayout');
+      cy.intercept(
+        'PATCH',
+        '**/api/chrome-service/v1/dashboard-templates/*'
+      ).as('patchLayout');
+
+      resetToDefaultLayout();
+      cy.wait('@resetLayout').its('response.statusCode').should('eq', 200);
+      moveWidget(0, 1);
+      cy.wait('@patchLayout').its('response.statusCode').should('eq', 200);
+      getLayout().then((firstMove) => {
+        moveWidget(2, 1);
+        cy.wait('@patchLayout').its('response.statusCode').should('eq', 200);
+        getLayout().then((secondMove) => {
+          expect(secondMove).to.not.deep.equal(firstMove);
+        });
+      });
+      resetToDefaultLayout();
+      cy.wait('@resetLayout').its('response.statusCode').should('eq', 200);
+    });
   });
 });

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -13,7 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "baseUrl": "./",
-    "types": ["cypress", "node"],
+    "types": ["cypress", "node", "@t4w/cypress-drag-drop"],
     "allowJs": false
   },
   "include": ["./**/*.ts", "./**/*.tsx"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "redux-promise-middleware": "^6.1.2"
       },
       "devDependencies": {
+        "@4tw/cypress-drag-drop": "^2.2.5",
         "@cypress/code-coverage": "^3.12.9",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^2.0.3",
         "@redhat-cloud-services/frontend-components-config": "^6.0.14",
@@ -70,6 +71,15 @@
       "engines": {
         "node": ">=15.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@4tw/cypress-drag-drop": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.2.5.tgz",
+      "integrity": "sha512-3ghTmzhOmUqeN6U3QmUnKRUxI7OMLbJA4hHUY/eS/FhWJgxbiGgcaELbolWnBAOpajPXcsNQGYEj9brd59WH6A==",
+      "dev": true,
+      "peerDependencies": {
+        "cypress": "2 - 13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "redux-promise-middleware": "^6.1.2"
   },
   "devDependencies": {
+    "@4tw/cypress-drag-drop": "^2.2.5",
     "@cypress/code-coverage": "^3.12.9",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^2.0.3",
     "@redhat-cloud-services/frontend-components-config": "^6.0.14",


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Adds a cypress test to check the following:
- Widgets can be moved
- After widgets are moved, an associated PATCH request is sent to the API.
- The 'Reset to default' button resets the layout

[RHCLOUD-32149](https://issues.redhat.com/browse/RHCLOUD-32149)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->


---

### Checklist ☑️
- [X] PR only fixes one issue or story <!-- open new PR for others -->
- [X] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [X] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [X] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [X] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
