### PR TITLE
remove href from guided tour button

### DIFF
--- a/src/components/widgets/explore-capabilities.tsx
+++ b/src/components/widgets/explore-capabilities.tsx
@@ -29,6 +29,7 @@ const ExploreCapabilities: React.FunctionComponent = () => {
       title: 'Take a tour of the Console',
       body: "There's a lot to explore in the Hybrid Cloud Console, and understanding its capabilities will increase your efficiency.",
       buttonName: 'Start the guided tour',
+      ouiaId: 'start-guided-tour-button',
     },
     {
       id: 'ex-toggle2',
@@ -133,6 +134,7 @@ const ExploreCapabilities: React.FunctionComponent = () => {
                 size="lg"
                 href={drawerData[activeItem].url}
                 className="pf-m-danger pf-v5-u-mb-sm"
+                ouiaId={drawerData[activeItem].ouiaId}
               >
                 {drawerData[activeItem].buttonName}
               </Button>


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
- Remove the href for the 'Start the Guided Tour' button in the Explore Capabilities Widget
- Opening the guided tour will be handled within Pendo
- Button set to use OUIA ID of `start-guided-tour-button`

[RHCLOUD-32221](https://issues.redhat.com/browse/RHCLOUD-32221)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [X] PR only fixes one issue or story <!-- open new PR for others -->
- [X] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [X] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [X] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [X] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
