### PR TITLE
(RHCLOUD-32752): Add e2e tests for openshift AI widget

### DIFF
--- a/cypress/e2e/widgets/openshift-ai.cy.ts
+++ b/cypress/e2e/widgets/openshift-ai.cy.ts
@@ -1,0 +1,48 @@
+describe('Openshift AI widget', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/');
+
+    cy.intercept(
+      'GET',
+      '**/api/chrome-service/v1/dashboard-templates?dashboard=landingPage'
+    ).as('resetLayout');
+
+    cy.intercept('PATCH', '**/api/chrome-service/v1/dashboard-templates/*').as(
+      'patchLayout'
+    );
+
+    cy.wait('@resetLayout').its('response.statusCode').should('eq', 200);
+  });
+
+  it('should appear on default layout', () => {
+    cy.get(`[data-ouia-component-id="landing-openshiftAi-widget"]`).should(
+      'exist'
+    );
+  });
+
+  it('should have correct link', () => {
+    cy.get(`[data-ouia-component-id="landing-openshiftAi-widget"] a`)
+      .should('have.attr', 'href')
+      .and(
+        'include',
+        'https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial'
+      );
+  });
+
+  it('should be removed if clicked on remove', () => {
+    cy.get(
+      `[data-ouia-component-id="landing-openshiftAi-widget"] button.pf-v5-c-menu-toggle`
+    ).click();
+    cy.contains('.pf-v5-c-menu__item-text', 'Remove').click();
+    cy.wait('@patchLayout').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+      const firstMove = response?.body?.data;
+      expect(firstMove).to.not.be.null;
+
+      cy.get(`[data-ouia-component-id="landing-openshiftAi-widget"]`).should(
+        'not.exist'
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Description

Add basic E2E tests to check if openshift AI widget has the right content.

[RHCLOUD-32752](https://issues.redhat.com/browse/RHCLOUD-32752)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
