### PR TITLE
fix(RHINENG-9615): Fix CentOS card, remove space before call to action buttons

### DIFF
--- a/cypress/e2e/widgets/openshift-ai.cy.ts
+++ b/cypress/e2e/widgets/openshift-ai.cy.ts
@@ -19,6 +19,9 @@ describe('Openshift AI widget', () => {
   });
 
   it('should be removed if clicked on remove', () => {
+    cy.get('[data-ouia-component-id="landing-openshiftAi-widget"]').contains(
+      'Red Hat OpenShift AI'
+    ); // wait for the widget to fully load firest
     cy.get(
       `[data-ouia-component-id="landing-openshiftAi-widget"] button.pf-v5-c-menu-toggle`
     ).click();

--- a/src/components/widgets/explore-capabilities.scss
+++ b/src/components/widgets/explore-capabilities.scss
@@ -48,6 +48,9 @@
   .pf-v5-c-simple-list__item-link {
     height: 100%;
   }
+  .cta-button {
+    margin-top: var(--pf-v5-global--spacer--md);
+  }
   @container (width < 1080px) { 
     .title {
       font-size: var(--pf-v5-global--FontSize--lg);

--- a/src/components/widgets/explore-capabilities.tsx
+++ b/src/components/widgets/explore-capabilities.tsx
@@ -3,7 +3,6 @@ import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import {
   Card,
   CardBody,
-  CardFooter,
 } from '@patternfly/react-core/dist/dynamic/components/Card';
 import { Drawer } from '@patternfly/react-core/dist/dynamic/components/Drawer';
 import { DrawerContent } from '@patternfly/react-core/dist/dynamic/components/Drawer';
@@ -73,25 +72,28 @@ const ExploreCapabilities: React.FunctionComponent = () => {
       img: '/apps/frontend-assets/console-landing/widget-explore/Explore_CentOS-to-RHEL.svg',
       title: 'Convert your CentOS systems to Red Hat Enterprise Linux',
       body: (
-        <span>
-          On June 30, 2024, CentOS Linux 7 will reach End of Life (EOL), and
-          those systems will stop receiving updates, security patches, and new
-          features.
-          <br></br>
-          Red Hat can help.{' '}
-          <a
-            href="https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/centos-migration"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Learn more
-          </a>{' '}
-          about migrating your CentOS Linux systems to RHEL, whether on-premise
-          or in the cloud.
-        </span>
+        <div>
+          <p>
+            On June 30, 2024, CentOS Linux 7 will reach End of Life (EOL), and
+            those systems will stop receiving updates, security patches, and new
+            features.
+          </p>
+          <p>
+            Red Hat can help.{' '}
+            <a
+              href="https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/centos-migration"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Learn more
+            </a>{' '}
+            about migrating your CentOS Linux systems to RHEL, whether
+            on-premise or in the cloud.
+          </p>
+        </div>
       ),
       buttonName: 'Run a pre-conversion analysis',
-      url: 'https://console.redhat.com/insights/tasks?quickstart=insights-tasks-pre-conversion#SIDs=&tags=',
+      url: 'https://console.redhat.com/insights/tasks/available/convert-to-rhel-preanalysis?quickstart=insights-tasks-pre-conversion',
     },
     {
       id: 'ex-toggle7',
@@ -127,18 +129,16 @@ const ExploreCapabilities: React.FunctionComponent = () => {
                   {drawerData[activeItem].body}
                 </Text>
               </TextContent>
-            </CardBody>
-            <CardFooter className="pf-v5-u-p-0">
               <Button
                 component="a"
                 size="lg"
                 href={drawerData[activeItem].url}
-                className="pf-m-danger pf-v5-u-mb-sm"
+                className="pf-m-danger pf-v5-u-mb-sm cta-button"
                 ouiaId={drawerData[activeItem].ouiaId}
               >
                 {drawerData[activeItem].buttonName}
               </Button>
-            </CardFooter>
+            </CardBody>
           </Card>
           <img
             className="widg-explore-image pf-v5-u-align-self-flex-start pf-v5-u-flex-none pf-v5-u-m-lg"


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-9615.

### Description

This slightly improves the CentOS card look and updates the link for the call to action button. Also, moves the call to action button from every card from footer to the card body.

---

### Screenshots

#### Before:

![Screenshot 2024-05-30 at 15 26 56](https://github.com/RedHatInsights/landing-page-frontend/assets/31385370/539176ad-77a7-40eb-87cd-30e539eb651f)

#### After:

![Screenshot 2024-05-30 at 15 27 32](https://github.com/RedHatInsights/landing-page-frontend/assets/31385370/19788fbe-164f-4c84-84fa-02cb83214228)

---

### Checklist ☑️
- [X] PR only fixes one issue or story <!-- open new PR for others -->
- [ X Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [X] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [X] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
