### PR TITLE
RHCLOUD-32149 Widget can be locked

### DIFF
--- a/cypress/e2e/lock-widget.cy.ts
+++ b/cypress/e2e/lock-widget.cy.ts
@@ -1,0 +1,47 @@
+import '@4tw/cypress-drag-drop';
+
+const moveWidget = (sourceIndex: number, targetIndex: number) => {
+  cy.get('.drag-handle')
+    .eq(sourceIndex)
+    .then((source) => {
+      const targetSelector = `.drag-handle:eq(${targetIndex})`;
+      cy.wrap(source).drag(targetSelector);
+    });
+};
+
+describe('Widgets can lock and unlock', () => {
+  beforeEach(() => {
+    cy.loadLandingPage();
+  });
+
+  it('should lock widget', () => {
+    cy.wait(2000);
+    cy.get('[aria-label="widget actions menu toggle"]').first().click();
+    cy.get('[data-ouia-component-id="lock-widget"]').first().click();
+  });
+
+  it('widgets can be dragged and dropped', () => {
+    moveWidget(0, 1);
+
+    cy.wait('@patchLayout').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+      const firstMove = response?.body?.data;
+      expect(firstMove).to.be.null;
+    });
+
+    it('should unlock widget', () => {
+      const widgetSelector = '.react-grid-item';
+      cy.wait(2000);
+      const initialHeight =
+        Cypress.$(widgetSelector)[0].getBoundingClientRect().height;
+      cy.wait(2000);
+      cy.get('[aria-label="widget actions menu toggle"]').first().click();
+      cy.get('[data-ouia-component-id="unlock-widget"]').first().click();
+      cy.wait(2000).then(() => {
+        const minimizedHeight =
+          Cypress.$(widgetSelector)[0].getBoundingClientRect().height;
+        expect(minimizedHeight).to.be.lessThan(initialHeight);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
description text...

[RHCLOUDXXXX](https://issues.redhat.com/browse/RHCLOUDXXXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
