### PR TITLE
RHCLOUD-33740, RHCLOUD-33745, RHCLOUD-33746: Fix OUIA ID for the reset confirmation modal button

### DIFF
--- a/cypress/e2e/widgets-landing.cy.ts
+++ b/cypress/e2e/widgets-landing.cy.ts
@@ -12,6 +12,7 @@ describe('Widget Landing Page', () => {
   });
 
   // Test skipped until issue with NaN on PATCH is resolved (makes test flaky)
+  // Related JIRA issue: https://issues.redhat.com/browse/RHCLOUD-33743
   xit('closes all the widgets', () => {
     // Ensure that widgets are open and displayed (Number of items in grid expected to be numDefaultWidgets)
     const numDefaultWidgets = 9;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -77,7 +77,7 @@ Cypress.Commands.add('resetToDefaultLayout', () => {
     .click()
     .get('#warning-modal-check')
     .click()
-    .get("button[data-ouia-component-id='primary-confirm-button']")
+    .get("button[data-ouia-component-id='WarningModal-confirm-button']")
     .click();
   cy.wait('@resetLayout').its('response.statusCode').should('eq', 200);
 });


### PR DESCRIPTION
### Description

Addresses test breakage by updating the OUIA ID of the dashboard reset confirmation modal's reset button in the `resetToDefaultLayout` command.

[RHCLOUD-33746](https://issues.redhat.com/browse/RHCLOUD-33746)
[RHCLOUD-33745](https://issues.redhat.com/browse/RHCLOUD-33745)
[RHCLOUD-33740](https://issues.redhat.com/browse/RHCLOUD-33740)

---

### Screenshots
N/A

#### Before:

N/A

#### After:

N/A

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
