### PR TITLE
Fix external link when empty support cases

### DIFF
--- a/src/components/widgets/support-case-widget.tsx
+++ b/src/components/widgets/support-case-widget.tsx
@@ -23,6 +23,9 @@ import SkeletonTable from '@patternfly/react-component-groups/dist/dynamic/Skele
 import { MAX_ROWS, columnNames, getUrl, labelColor } from '../../utils/consts';
 import './support-case-widget.scss';
 
+const SUPPORT_CASE_URL =
+  'https://access.redhat.com/support/cases/#/case/new/get-support?caseCreate=true';
+
 export type Case = {
   id: string;
   caseNumber: string;
@@ -97,7 +100,10 @@ const SupportCaseWidget: React.FunctionComponent = () => {
             variant="link"
             icon={<ExternalLinkAltIcon />}
             iconPosition="end"
-            href="https://access.redhat.com/support/cases/#/case/new/get-support?caseCreate=true"
+            href={SUPPORT_CASE_URL}
+            onClick={() => {
+              window.open(SUPPORT_CASE_URL, '_blank');
+            }}
           >
             Open a support case
           </Button>


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
When user doesn't have any support cases opened empty state is shown with call to action button, however this button doesn't work properly. This PR fixes such issue.

[RHCLOUD-33907](https://issues.redhat.com/browse/RHCLOUD-33907)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
