### PR TITLE
Fix failing rhel test by targeting correct element

### DIFF
--- a/cypress/e2e/widgets-landing.cy.ts
+++ b/cypress/e2e/widgets-landing.cy.ts
@@ -13,7 +13,7 @@ describe('Widget Landing Page', () => {
 
   // Test skipped until issue with NaN on PATCH is resolved (makes test flaky)
   // Related JIRA issue: https://issues.redhat.com/browse/RHCLOUD-33743
-  xit('closes all the widgets', () => {
+  it('closes all the widgets', () => {
     // Ensure that widgets are open and displayed (Number of items in grid expected to be numDefaultWidgets)
     const numDefaultWidgets = 9;
     const cardActionsSelector = '[aria-label="widget actions menu toggle"]';

--- a/cypress/e2e/widgets/rhel.cy.ts
+++ b/cypress/e2e/widgets/rhel.cy.ts
@@ -17,9 +17,7 @@ describe('RHEL widget', () => {
     cy.get(
       `[data-ouia-component-id="landing-rhel-widget"] button.pf-v5-c-menu-toggle`
     ).click();
-    cy.get(
-      '[data-ouia-component-id="landing-rhel-widget"] [data-ouia-component-id="remove-widget"]'
-    ).click();
+    cy.get('[data-ouia-component-id="remove-widget"]').click();
     cy.get(`[data-ouia-component-id="landing-rhel-widget"]`).should(
       'not.exist'
     );


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Fix incorrect remove selector in RHEL widget. Enable back test to remove all widgets from landing page. We should focus in widget-layout repository on the NaN requests instead of ignoring this test.

[RHCLOUD-33743](https://issues.redhat.com/browse/RHCLOUD-33743)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
