### PR TITLE
Stabilize widget removal, widget locking tests

### DIFF
--- a/cypress/e2e/lock-widget.cy.ts
+++ b/cypress/e2e/lock-widget.cy.ts
@@ -13,7 +13,14 @@ describe('Widgets can lock and unlock', () => {
     cy.get('[data-ouia-component-id="landing-rhel-widget"] .drag-handle')
       .invoke('show')
       .trigger('mouseenter')
-      .wait(1000);
+      .wait(5000);
+
+    // hovertext "Move" sticks on the page, click somewhere else within the widget to make it go away
+    // there's probably a better way to do this
+    cy.get('[data-ouia-component-id="landing-rhel-widget"]')
+      .contains('Red Hat Enterprise Linux')
+      .click();
+
     cy.get('[aria-label="Move widget"]')
       .should('be.visible')
       .and('contain', 'Widget locked');

--- a/cypress/e2e/lock-widget.cy.ts
+++ b/cypress/e2e/lock-widget.cy.ts
@@ -1,29 +1,25 @@
 describe('Widgets can lock and unlock', () => {
   beforeEach(() => {
     cy.loadLandingPage();
+    cy.viewport(1920, 1080);
   });
 
   it('should lock widget, show that the ability to move is unavailable and return to menu to unlock widget', () => {
     // lock widget
-    cy.get('[data-ouia-component-id="landing-rhel-widget"]');
     cy.get('[aria-label="widget actions menu toggle"]').first().click();
-    cy.get('[data-ouia-component-id="lock-widget"]').first().click();
+    cy.get('[data-ouia-component-id="lock-widget"]').first().click().wait(2000);
 
-    // show that widget can't move
-    cy.get('[data-ouia-component-id="landing-rhel-widget"] .drag-handle')
-      .invoke('show')
-      .trigger('mouseenter')
-      .wait(5000);
+    // try moving the widget
+    const dragHandleLocator =
+      '[data-ouia-component-id="landing-rhel-widget"] .drag-handle';
 
-    // hovertext "Move" sticks on the page, click somewhere else within the widget to make it go away
-    // there's probably a better way to do this
-    cy.get('[data-ouia-component-id="landing-rhel-widget"]')
-      .contains('Red Hat Enterprise Linux')
-      .click();
+    const destLocator = '[data-ouia-component-id="landing-openshift-widget"]';
+    cy.dragTotarget(dragHandleLocator, destLocator);
 
-    cy.get('[aria-label="Move widget"]')
-      .should('be.visible')
-      .and('contain', 'Widget locked');
+    // indirectly check if the widget moved (should still be the first in the list of cards)
+    cy.get('[id="widget-layout-container"] .react-grid-item')
+      .first()
+      .contains('Red Hat Enterprise Linux');
 
     // unlock widget
     cy.get('[data-ouia-component-id="landing-rhel-widget"]');

--- a/cypress/e2e/widgets/openshift-ai.cy.ts
+++ b/cypress/e2e/widgets/openshift-ai.cy.ts
@@ -1,7 +1,6 @@
 describe('Openshift AI widget', () => {
   beforeEach(() => {
     cy.loadLandingPage();
-    cy.wait(5000);
   });
 
   it('should appear on default layout', () => {

--- a/cypress/e2e/widgets/openshift-ai.cy.ts
+++ b/cypress/e2e/widgets/openshift-ai.cy.ts
@@ -20,16 +20,10 @@ describe('Openshift AI widget', () => {
   });
 
   it('should be removed if clicked on remove', () => {
-    cy.get('[data-ouia-component-id="landing-openshiftAi-widget"]').contains(
-      'Red Hat OpenShift AI'
-    ); // wait for the widget to fully load firest
-    cy.get(
-      `[data-ouia-component-id="landing-openshiftAi-widget"] button.pf-v5-c-menu-toggle`
-    ).click();
-    cy.contains('.pf-v5-c-menu__item-text', 'Remove').click();
-    cy.wait(3000);
-    cy.get(`[data-ouia-component-id="landing-openshiftAi-widget"]`).should(
-      'not.exist'
-    );
+    const widgetId = 'landing-openshiftAi-widget';
+    cy.get(`[data-ouia-component-id="${widgetId}"]`)
+      .scrollIntoView()
+      .should('be.visible');
+    cy.removeWidget('landing-openshiftAi-widget');
   });
 });

--- a/cypress/e2e/widgets/openshift-ai.cy.ts
+++ b/cypress/e2e/widgets/openshift-ai.cy.ts
@@ -1,6 +1,7 @@
 describe('Openshift AI widget', () => {
   beforeEach(() => {
     cy.loadLandingPage();
+    cy.wait(5000);
   });
 
   it('should appear on default layout', () => {

--- a/cypress/e2e/widgets/openshift-rhel.cy.ts
+++ b/cypress/e2e/widgets/openshift-rhel.cy.ts
@@ -1,18 +1,5 @@
 describe('Red Hat OpenShift Widget', () => {
   const widgetId = 'landing-openshift-widget';
-  // Jenkins runner seems to need this
-  const jenkinsWait = 3000;
-  const removeWidget = (widgetId: string) => {
-    // we're trying to use IDs instead of selectors, thus "within"
-    cy.get(`[data-ouia-component-id="${widgetId}"]`).within(() => {
-      cy.get('[aria-label="widget actions menu toggle"]').click();
-    });
-    cy.get('[data-ouia-component-id="remove-widget"]')
-      .click()
-      .wait('@patchLayout')
-      .wait(jenkinsWait);
-    cy.get(`[data-ouia-component-id="${widgetId}]`).should('not.exist');
-  };
 
   beforeEach(() => {
     cy.login();
@@ -48,6 +35,6 @@ describe('Red Hat OpenShift Widget', () => {
   it('disappears when removed from the layout', () => {
     cy.resetToDefaultLayout();
     cy.get(`[data-ouia-component-id="${widgetId}"]`).should('be.visible');
-    removeWidget(widgetId);
+    cy.removeWidget(widgetId);
   });
 });

--- a/cypress/e2e/widgets/rhel.cy.ts
+++ b/cypress/e2e/widgets/rhel.cy.ts
@@ -15,12 +15,8 @@ describe('RHEL widget', () => {
   });
 
   it('should be removed if clicked on remove', () => {
-    cy.get(
-      `[data-ouia-component-id="landing-rhel-widget"] button.pf-v5-c-menu-toggle`
-    ).click();
-    cy.get('[data-ouia-component-id="remove-widget"]').click();
-    cy.get(`[data-ouia-component-id="landing-rhel-widget"]`).should(
-      'not.exist'
-    );
+    const widgetId = 'landing-rhel-widget';
+    cy.get(`[data-ouia-component-id="${widgetId}"]`).should('be.visible');
+    cy.removeWidget(widgetId);
   });
 });

--- a/cypress/e2e/widgets/rhel.cy.ts
+++ b/cypress/e2e/widgets/rhel.cy.ts
@@ -1,7 +1,6 @@
 describe('RHEL widget', () => {
   beforeEach(() => {
     cy.loadLandingPage();
-    cy.wait(5000);
   });
 
   it('should appear on default layout', () => {

--- a/cypress/e2e/widgets/rhel.cy.ts
+++ b/cypress/e2e/widgets/rhel.cy.ts
@@ -1,6 +1,7 @@
 describe('RHEL widget', () => {
   beforeEach(() => {
     cy.loadLandingPage();
+    cy.wait(5000);
   });
 
   it('should appear on default layout', () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -121,8 +121,6 @@ Cypress.Commands.add('loadLandingPage', () => {
 });
 
 Cypress.Commands.add('removeWidget', (widgetId: string) => {
-  // runner on jenkins is a bit slow, wait for a long while
-  const jenkinsWait = 5000;
   cy.intercept('PATCH', '**/api/chrome-service/v1/dashboard-templates/*').as(
     'patchLayout'
   );
@@ -132,7 +130,6 @@ Cypress.Commands.add('removeWidget', (widgetId: string) => {
   });
   cy.get('[data-ouia-component-id="remove-widget"]')
     .click()
-    .wait('@patchLayout')
-    .wait(jenkinsWait);
+    .wait('@patchLayout');
   cy.get(`[data-ouia-component-id="${widgetId}]`).should('not.exist');
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -119,3 +119,20 @@ Cypress.Commands.add('loadLandingPage', () => {
 
   cy.resetToDefaultLayout();
 });
+
+Cypress.Commands.add('removeWidget', (widgetId: string) => {
+  // runner on jenkins is a bit slow, wait for a long while
+  const jenkinsWait = 5000;
+  cy.intercept('PATCH', '**/api/chrome-service/v1/dashboard-templates/*').as(
+    'patchLayout'
+  );
+
+  cy.get(`[data-ouia-component-id="${widgetId}"]`).within(() => {
+    cy.get('[aria-label="widget actions menu toggle"]').click();
+  });
+  cy.get('[data-ouia-component-id="remove-widget"]')
+    .click()
+    .wait('@patchLayout')
+    .wait(jenkinsWait);
+  cy.get(`[data-ouia-component-id="${widgetId}]`).should('not.exist');
+});

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -43,6 +43,7 @@ declare global {
         targetSelector: string
       ): Chainable<void>;
       loadLandingPage(): Chainable<void>;
+      removeWidget(widgetId: string): void;
     }
   }
 }


### PR DESCRIPTION
### Description
Test stabilization is the objective of this PR.

1. Defines `removeWidget` command, taken from logic in `openshift-rhel.cy.ts`
2. Updates `rhel.cy.ts` and `openshift-ai.cy.ts` to consume reusable `removeWidget` command.
3. Adjust the lock widget test to verify non-move of the locked widget with a drag command
---
### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
