### PR TITLE
Create e2e test for favorite services widget

### DIFF
--- a/cypress/e2e/widgets/favorite-services.cy.ts
+++ b/cypress/e2e/widgets/favorite-services.cy.ts
@@ -1,0 +1,102 @@
+interface FavoritePage {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+  pathname: string;
+  favorite: boolean;
+  userIdentityId: number;
+}
+
+describe('My Favorite Services Widget', () => {
+  const widgetId = 'chrome-favoriteServices-widget';
+
+  beforeEach(() => {
+    cy.intercept(
+      'GET',
+      '**/api/chrome-service/v1/dashboard-templates?dashboard=landingPage'
+    ).as('resetLayout');
+
+    cy.intercept('PATCH', '**/api/chrome-service/v1/dashboard-templates/*').as(
+      'patchLayout'
+    );
+    replaceFavorites([]);
+
+    cy.login();
+    cy.visit('/');
+
+    cy.intercept('GET', '**/api/chrome-service/v1/user').as('getFavorites');
+
+    cy.wait('@resetLayout').its('response.statusCode').should('eq', 200);
+  });
+
+  const replaceFavorites = (favorites: FavoritePage[]) => {
+    cy.intercept('GET', '**/api/chrome-service/v1/user', (req) => {
+      req.continue((res) => {
+        const body = JSON.parse(res.body);
+        body.data.favoritePages = favorites;
+        res.body = JSON.stringify(body);
+      });
+    }).as('getFavorites');
+  };
+
+  it('appears in the default layout', () => {
+    // Reset layout to the default
+    cy.resetToDefaultLayout();
+
+    cy.get(`[data-ouia-component-id="${widgetId}"]`).should('be.visible');
+    cy.resetToDefaultLayout();
+  });
+
+  it('disappears when removed from the layout', () => {
+    cy.resetToDefaultLayout();
+    cy.get(`[data-ouia-component-id="${widgetId}"]`).should('be.visible');
+    cy.removeWidget(widgetId);
+  });
+
+  it('displays the empty state when no favorites are set', () => {
+    cy.resetToDefaultLayout();
+    cy.wait('@getFavorites');
+
+    cy.get(`[data-ouia-component-id="${widgetId}"]`)
+      .should('be.visible')
+      .within(() => {
+        cy.get('h3').should('contain', 'No favorited services');
+      });
+  });
+
+  it('displays the favorites when they are set', () => {
+    const testFavorites: FavoritePage[] = [
+      {
+        id: 665,
+        createdAt: '2024-08-02T19:52:52.29345Z',
+        updatedAt: '2024-08-02T19:52:52.29345Z',
+        deletedAt: null,
+        pathname: '/settings/notifications',
+        favorite: true,
+        userIdentityId: 1,
+      },
+      {
+        id: 664,
+        createdAt: '2024-08-02T19:52:51.305442Z',
+        updatedAt: '2024-08-02T19:52:51.305442Z',
+        deletedAt: null,
+        pathname: '/settings/integrations',
+        favorite: true,
+        userIdentityId: 1,
+      },
+    ];
+
+    replaceFavorites(testFavorites);
+    cy.visit('/');
+    cy.resetToDefaultLayout();
+    cy.wait('@getFavorites');
+
+    cy.get(`[data-ouia-component-id="${widgetId}"]`)
+      .should('be.visible')
+      .within(() => {
+        cy.get('p').should('contain', 'Notifications');
+        cy.get('p').should('contain', 'Integrations');
+      });
+  });
+});

--- a/cypress/e2e/widgets/rhel.cy.ts
+++ b/cypress/e2e/widgets/rhel.cy.ts
@@ -10,7 +10,7 @@ describe('RHEL widget', () => {
   it('should have correct link', () => {
     cy.get(`[data-ouia-component-id="landing-rhel-widget"] a`)
       .should('have.attr', 'href')
-      .and('include', `/preview/insights/`);
+      .and('include', `/insights/`);
   });
 
   it('should be removed if clicked on remove', () => {


### PR DESCRIPTION
### Create e2e test for favorite services widget
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Adds basic test coverage to ensure that the Favorite Services widget doesn't regress or change unexpectedly.
- Widget appears in default layout and on layout reset
- Widget disappears when removed
- List displays services that have been favorited
- Empty state displays when no services are favorited

[RHCLOUD-32749](https://issues.redhat.com/browse/RHCLOUD-32749)

---


### Checklist ☑️
- [X] PR only fixes one issue or story <!-- open new PR for others -->
- [X] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [X] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [X] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [X] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
