### PR TITLE
RHINENG-10825: Rename convert-to-rhel-preanalysis slug

### DIFF
--- a/cypress/e2e/widgets/explore-capabilities.cy.ts
+++ b/cypress/e2e/widgets/explore-capabilities.cy.ts
@@ -48,7 +48,7 @@ describe('Explore Capabilities widget', () => {
       tabHeading: 'Convert your CentOS systems to RHEL',
       contentHeader: 'Convert your CentOS systems to Red Hat Enterprise Linux',
       buttonText: 'Run a pre-conversion analysis',
-      expectedLinkDest: '/insights/tasks/available/convert-to-rhel-preanalysis',
+      expectedLinkDest: '/insights/tasks/available/convert-to-rhel-analysis',
     },
     {
       tabHeading: 'Configure your console',

--- a/src/components/widgets/explore-capabilities.tsx
+++ b/src/components/widgets/explore-capabilities.tsx
@@ -98,7 +98,7 @@ const ExploreCapabilities: React.FunctionComponent = () => {
       ),
       buttonName: 'Run a pre-conversion analysis',
       ouiaId: 'cent-os-button',
-      url: '/insights/tasks/available/convert-to-rhel-preanalysis?quickstart=insights-tasks-pre-conversion',
+      url: '/insights/tasks/available/convert-to-rhel-analysis?quickstart=insights-tasks-pre-conversion',
     },
     {
       id: 'ex-toggle7',


### PR DESCRIPTION
### Description
Rename of task slug, so `convert-to-rhel-preanalysis` is changed to `convert-to-rhel-analysis`. (It's already in prod and renamed on other places, see the jira issue for detailed disscussions and other PRs)
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->


[RHINENG-10825](https://issues.redhat.com/browse/RHINENG-10825)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
I don't really know where the button is, but I did simple search through all RedHatInsights repos, the previous slug won't work it will return 404, new one is already in production environment.

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
  - Not needed, it's just changed link that was already there 
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
