### PR TITLE
Update pr_check.sh - temporarily skip cypress tests

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -15,18 +15,20 @@ CHROME_CONTAINER_NAME=chrome-$CHROME_SHA
 
 docker run -d --name $CHROME_CONTAINER_NAME --replace --network bridge quay.io/cloudservices/insights-chrome-frontend:$CHROME_SHA
 
-CHROME_HOST=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $CHROME_CONTAINER_NAME)
-docker run -t \
-  -v $PWD:/e2e:ro,Z \
-  -w /e2e \
-  -e CHROME_ACCOUNT=$CHROME_ACCOUNT \
-  -e CHROME_PASSWORD=$CHROME_PASSWORD \
-  -e CHROME_HOST=$CHROME_HOST \
-  --add-host stage.foo.redhat.com:127.0.0.1 \
-  --add-host prod.foo.redhat.com:127.0.0.1 \
-  --entrypoint bash \
-  --network bridge \
-  quay.io/cloudservices/cypress-e2e-image:b8480a8 /e2e/run-e2e.sh
+# NOTE: CYPRESS TESTS SKIPPED DUE TO LOGIN PAGE ISSUES IN STAGE ENV
+
+# CHROME_HOST=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $CHROME_CONTAINER_NAME)
+# docker run -t \
+#   -v $PWD:/e2e:ro,Z \
+#   -w /e2e \
+#   -e CHROME_ACCOUNT=$CHROME_ACCOUNT \
+#   -e CHROME_PASSWORD=$CHROME_PASSWORD \
+#   -e CHROME_HOST=$CHROME_HOST \
+#   --add-host stage.foo.redhat.com:127.0.0.1 \
+#   --add-host prod.foo.redhat.com:127.0.0.1 \
+#   --entrypoint bash \
+#   --network bridge \
+#   quay.io/cloudservices/cypress-e2e-image:b8480a8 /e2e/run-e2e.sh
 
 # ---------------------------
 # Build and Publish to Quay


### PR DESCRIPTION

### Description
Cypress tests are broken because of changes to the login page in stage env. This temporarily disables them - no point in running failing tests over and over.

---

### Screenshots
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
