### PR TITLE
[HMS-5265]: Replace edge widget with a new image-builder

### DIFF
--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -19,7 +19,7 @@ describe('Dashboard with widgets is displayed', () => {
       'landing-recentlyVisited-widget',
       'chrome-favoriteServices-widget',
       'landing-openshiftAi-widget',
-      'landing-edge-widget',
+      'landing-imageBuilder-widget',
       'landing-acs-widget',
     ];
 

--- a/fec.config.js
+++ b/fec.config.js
@@ -49,6 +49,10 @@ module.exports = {
         __dirname,
         'src/components/widgets/edge-widget.tsx'
       ),
+      './ImageBuilderWidget': path.resolve(
+        __dirname,
+        'src/components/widgets/image-builder-widget.tsx'
+      ),
       './RhelWidget': path.resolve(
         __dirname,
         'src/components/widgets/rhel-widget.tsx'

--- a/src/components/widgets/image-builder-widget.tsx
+++ b/src/components/widgets/image-builder-widget.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { SimpleServiceWidget } from './simple-service-widget';
+
+const ImageBuilderWidget: React.FunctionComponent = () => {
+  return (
+    <>
+      <SimpleServiceWidget
+        id={3}
+        body="Create customized system images for disks, VMs, and cloud platforms. Image Builder automates configurations, saving you time and ensuring consistent, deployment-ready images every time."
+        linkTitle="Images"
+        url="/insights/image-builder"
+      />
+    </>
+  );
+};
+
+export default ImageBuilderWidget;


### PR DESCRIPTION
### Description
This PR replaces the outdated Edge service widget with a new widget showcasing the "Image Builder" service. The updated widget should provide a clear, concise description of Image Builder's capabilities and include a link for the service.

---

### Screenshots

#### Before:
![Screenshot 2025-01-07 at 13 36 00](https://github.com/user-attachments/assets/7d271fc7-9e86-475e-8c4b-7710d577631a)


#### After:

![Screenshot 2025-01-07 at 12 54 39](https://github.com/user-attachments/assets/1b07b4ee-0390-463c-b5ae-05d5ee85a79e)

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
