### PR TITLE
feat: Add parameter for layout types to select desired default widget layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ export const PermissionContext = createContext<{
   isOrgAdmin?: boolean;
 }>({});
 
-const App = () => {
+const App = ({ layoutType } : {layoutType?: string }) => {
   const [isOrgAdmin, setIsOrgAdmin] = useState<boolean>(false);
   const chrome = useChrome();
   const navigate = useNavigate();
@@ -98,7 +98,7 @@ const App = () => {
           }
         >
           <Routes>
-            <Route path={routes.landing} element={<Landing />} />
+            <Route path={routes.landing} element={<Landing layoutType={layoutType} />} />
             <Route path={routes.maintenance} element={<Maintenance />} />
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ export const PermissionContext = createContext<{
   isOrgAdmin?: boolean;
 }>({});
 
-const App = ({ layoutType } : {layoutType?: string }) => {
+const App: React.FC<{ layoutType?: string }> = ({ layoutType }) => {
   const [isOrgAdmin, setIsOrgAdmin] = useState<boolean>(false);
   const chrome = useChrome();
   const navigate = useNavigate();
@@ -98,7 +98,10 @@ const App = ({ layoutType } : {layoutType?: string }) => {
           }
         >
           <Routes>
-            <Route path={routes.landing} element={<Landing layoutType={layoutType} />} />
+            <Route
+              path={routes.landing}
+              element={<Landing layoutType={layoutType} />}
+            />
             <Route path={routes.maintenance} element={<Maintenance />} />
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/moduleEntries/AppEntry.tsx
+++ b/src/moduleEntries/AppEntry.tsx
@@ -4,6 +4,6 @@ import App from '../App';
 const pathName = window.location.pathname.split('/');
 pathName.shift();
 
-const AppRoot = () => <App />;
+const AppRoot = ({ layoutType }: { layoutType?: string }) => <App layoutType={layoutType} />;
 
 export default AppRoot;

--- a/src/moduleEntries/AppEntry.tsx
+++ b/src/moduleEntries/AppEntry.tsx
@@ -4,6 +4,8 @@ import App from '../App';
 const pathName = window.location.pathname.split('/');
 pathName.shift();
 
-const AppRoot = ({ layoutType }: { layoutType?: string }) => <App layoutType={layoutType} />;
+const AppRoot: React.FC<{ layoutType?: string }> = ({ layoutType }) => (
+  <App layoutType={layoutType} />
+);
 
 export default AppRoot;

--- a/src/routes/Landing.tsx
+++ b/src/routes/Landing.tsx
@@ -3,12 +3,15 @@ import { useFlag } from '@unleash/proxy-client-react';
 import { ScalprumComponent } from '@scalprum/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-const Landing = () => {
+const Landing = ({ layoutType }: { layoutType?: string }) => {
   const scope = 'widgetLayout';
   const { isBeta } = useChrome();
   const widgetLayoutLandingPageEnabled =
     (isBeta() && useFlag('platform.landing-page.widgetization')) ||
     (!isBeta() && useFlag('platform.landing-page.widgetization-stable'));
+  const props = {
+    ...(layoutType && {layoutType: layoutType})
+  };
   return (
     <Fragment>
       {widgetLayoutLandingPageEnabled ? (
@@ -17,6 +20,7 @@ const Landing = () => {
           LoadingComponent={() => <></>}
           scope={scope}
           module="./WidgetLayout"
+          {...props}
         />
       ) : null}
     </Fragment>

--- a/src/routes/Landing.tsx
+++ b/src/routes/Landing.tsx
@@ -3,14 +3,14 @@ import { useFlag } from '@unleash/proxy-client-react';
 import { ScalprumComponent } from '@scalprum/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-const Landing = ({ layoutType }: { layoutType?: string }) => {
+const Landing: React.FC<{ layoutType?: string }> = ({ layoutType }) => {
   const scope = 'widgetLayout';
   const { isBeta } = useChrome();
   const widgetLayoutLandingPageEnabled =
     (isBeta() && useFlag('platform.landing-page.widgetization')) ||
     (!isBeta() && useFlag('platform.landing-page.widgetization-stable'));
   const props = {
-    ...(layoutType && {layoutType: layoutType})
+    ...(layoutType && { layoutType: layoutType }),
   };
   return (
     <Fragment>


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

This change allows for a `layoutType` to be passed as a property from fed-modules.json and used to set which custom widget layout to display on a user's first login. This is a requirement for itless environments as there are widgets that are hidden and not able to be displayed, leaving gaps in the default layout. If no layout is specified in `fed-modules.json`, then the original default layout is chosen.


---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![image](https://github.com/user-attachments/assets/49df95ab-5e72-4be1-b3e8-168f1100f383)


#### After:
![image](https://github.com/user-attachments/assets/f777fd1a-2345-4731-92c2-92124060a4e0)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
