### PR TITLE
fix: change Migration Advisor url to the new one

### DIFF
--- a/src/components/widgets/explore-capabilities.tsx
+++ b/src/components/widgets/explore-capabilities.tsx
@@ -62,7 +62,7 @@ const ExploreCapabilities: React.FunctionComponent = () => {
       title: 'Migration Advisor: VMware to Openshift',
       body: 'Discover your VMware environment, select a target cluster and create a migration plan.',
       ouiaId: 'migration-assessment-button',
-      url: '/openshift/migration-assessment',
+      url: '/openshift/migration-advisor',
     },
   ];
 


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
- Change Migration Advisor url to the new one. Replace 'migration-assessment' for 'migration-advisor'.
[ECOPROJECT-4009](https://redhat.atlassian.net/browse/ECOPROJECT-4009)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
This card point to https://console.stage.redhat.com/openshift/migration-assessment
<img width="384" height="142" alt="image" src="https://github.com/user-attachments/assets/2fb77a95-4dbe-4ca5-8cb1-70591f6558ed" />


#### After:
Now it points to https://console.stage.redhat.com/openshift/migration-advisor

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[ECOPROJECT-4009]: https://redhat.atlassian.net/browse/ECOPROJECT-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ