### PR TITLE
RHCLOUD-47547: Update logo in landing page Explore Capabilities widget

### DIFF
--- a/src/components/widgets/explore-capabilities.tsx
+++ b/src/components/widgets/explore-capabilities.tsx
@@ -40,7 +40,7 @@ const ExploreCapabilities: React.FunctionComponent = () => {
     },
     {
       id: 'card4',
-      img: '/apps/frontend-assets/technology-icons/insights.svg',
+      img: '/apps/frontend-assets/technology-icons/lightspeed.svg',
       alt: 'Red Hat Lightspeed logo',
       title: 'Analyze RHEL environments',
       body: 'Analyze platforms and applications from the console to better manage your hybrid cloud environments.',


### PR DESCRIPTION
### Description
Updated insights.svg to lightspeed.svg to reflect Insights rebrand to Red Hat Lightspeed on HCC. The impacted UI is the landing page at https://console.redhat.com/.
[RHCLOUD-47547](https://issues.redhat.com/browse/RHCLOUD-47547)

### Screenshots
#### Before:
<img width="496" height="467" alt="image" src="https://github.com/user-attachments/assets/7aa04bde-5814-4e1f-a846-07810e42a511" />

#### After:
<img width="516" height="606" alt="image" src="https://github.com/user-attachments/assets/cd87a152-c059-4592-b4a8-9ef73cf27bd3" />

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [x] _(Optional) QE: Potential impact to e2e tests
- [x] _(Optional) QE: Has been mentioned_
##

[RHCLOUD-47547]: https://redhat.atlassian.net/browse/RHCLOUD-47547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ