### PR TITLE
feat: add landing-landingPage layoutType prop to landing module

### DIFF
--- a/frontend.yml
+++ b/frontend.yml
@@ -28,6 +28,8 @@ objects:
           routes:
           - pathname: /
             exact: true
+            props:
+              layoutType: landing-landingPage
       widgetRegistry:
         - scope: "landing"
           module: "./ExploreCapabilities"


### PR DESCRIPTION
### Description
- Add `layoutType: landing-landingPage` prop to the landing module route configuration
- This prop is consumed by the widget-layout repo
