### PR TITLE
chore: disable Dependabot — updates handled by Konflux

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,2 @@
+version: 2
+updates: []


### PR DESCRIPTION
Dependabot is disabled because dependency updates are handled through centralized Konflux flows. This avoids duplicate PRs and reduces review noise.