### PR TITLE
fix(RHCLOUD-48967): Update base widget layout IDs to match widget mapping keys

### DIFF
--- a/frontend.yml
+++ b/frontend.yml
@@ -84,70 +84,70 @@ objects:
             sm:
               - cx: 0
                 cy: 0
-                i: 'rhel#rhel'
+                i: 'landing-./RhelWidget#rhel'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 1
-                i: 'openshift#openshift'
+                i: 'landing-./OpenShiftWidget#openshift'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 2
-                i: 'ansible#ansible'
+                i: 'landing-./AnsibleWidget#ansible'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 3
-                i: 'recentlyVisited#recentlyVisited'
+                i: 'landing-./RecentlyVisited#recentlyVisited'
                 w: 1
                 h: 5
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 4
-                i: 'favoriteServices#favoriteServices'
+                i: 'chrome-./DashboardFavorites#favoriteServices'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 5
-                i: 'subscriptions#subscriptions'
+                i: 'subscriptionInventory-./SubscriptionsWidget#subscriptions'
                 w: 1
                 h: 6
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 6
-                i: 'exploreCapabilities#exploreCapabilities'
+                i: 'landing-./ExploreCapabilities#exploreCapabilities'
                 w: 1
                 h: 13
                 maxH: 13
                 minH: 1
               - cx: 0
                 cy: 7
-                i: 'openshiftAi#openshiftAi'
+                i: 'landing-./OpenShiftAiWidget#openshiftAi'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 8
-                i: 'imageBuilder#imageBuilder'
+                i: 'landing-./ImageBuilderWidget#imageBuilder'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 9
-                i: 'acs#acs'
+                i: 'landing-./AcsWidget#acs'
                 w: 1
                 h: 4
                 maxH: 10
@@ -155,70 +155,70 @@ objects:
             md:
               - cx: 0
                 cy: 0
-                i: 'rhel#rhel'
+                i: 'landing-./RhelWidget#rhel'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 1
-                i: 'openshift#openshift'
+                i: 'landing-./OpenShiftWidget#openshift'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 2
-                i: 'ansible#ansible'
+                i: 'landing-./AnsibleWidget#ansible'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 1
                 cy: 0
-                i: 'recentlyVisited#recentlyVisited'
+                i: 'landing-./RecentlyVisited#recentlyVisited'
                 w: 1
                 h: 3
                 maxH: 10
                 minH: 1
               - cx: 1
                 cy: 1
-                i: 'favoriteServices#favoriteServices'
+                i: 'chrome-./DashboardFavorites#favoriteServices'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 1
                 cy: 2
-                i: 'subscriptions#subscriptions'
+                i: 'subscriptionInventory-./SubscriptionsWidget#subscriptions'
                 w: 1
                 h: 5
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 3
-                i: 'exploreCapabilities#exploreCapabilities'
+                i: 'landing-./ExploreCapabilities#exploreCapabilities'
                 w: 2
                 h: 6
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 4
-                i: 'imageBuilder#imageBuilder'
+                i: 'landing-./ImageBuilderWidget#imageBuilder'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 1
                 cy: 4
-                i: 'openshiftAi#openshiftAi'
+                i: 'landing-./OpenShiftAiWidget#openshiftAi'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 1
                 cy: 3
-                i: 'acs#acs'
+                i: 'landing-./AcsWidget#acs'
                 w: 2
                 h: 3
                 maxH: 10
@@ -226,70 +226,70 @@ objects:
             lg:
               - cx: 0
                 cy: 0
-                i: 'rhel#rhel'
+                i: 'landing-./RhelWidget#rhel'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 1
                 cy: 0
-                i: 'openshift#openshift'
+                i: 'landing-./OpenShiftWidget#openshift'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 1
-                i: 'ansible#ansible'
+                i: 'landing-./AnsibleWidget#ansible'
                 w: 2
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 4
-                i: 'exploreCapabilities#exploreCapabilities'
+                i: 'landing-./ExploreCapabilities#exploreCapabilities'
                 w: 2
                 h: 6
                 maxH: 10
                 minH: 1
               - cx: 2
                 cy: 0
-                i: 'recentlyVisited#recentlyVisited'
+                i: 'landing-./RecentlyVisited#recentlyVisited'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 2
                 cy: 2
-                i: 'favoriteServices#favoriteServices'
+                i: 'chrome-./DashboardFavorites#favoriteServices'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 2
                 cy: 3
-                i: 'subscriptions#subscriptions'
+                i: 'subscriptionInventory-./SubscriptionsWidget#subscriptions'
                 w: 1
                 h: 6
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 4
-                i: 'openshiftAi#openshiftAi'
+                i: 'landing-./OpenShiftAiWidget#openshiftAi'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 1
                 cy: 4
-                i: 'imageBuilder#imageBuilder'
+                i: 'landing-./ImageBuilderWidget#imageBuilder'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 2
                 cy: 4
-                i: 'acs#acs'
+                i: 'landing-./AcsWidget#acs'
                 w: 1
                 h: 4
                 maxH: 10
@@ -297,70 +297,70 @@ objects:
             xl:
               - cx: 0
                 cy: 0
-                i: 'rhel#rhel'
+                i: 'landing-./RhelWidget#rhel'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 1
                 cy: 0
-                i: 'openshift#openshift'
+                i: 'landing-./OpenShiftWidget#openshift'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 2
                 cy: 0
-                i: 'ansible#ansible'
+                i: 'landing-./AnsibleWidget#ansible'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 2
-                i: 'exploreCapabilities#exploreCapabilities'
+                i: 'landing-./ExploreCapabilities#exploreCapabilities'
                 w: 3
                 h: 6
                 maxH: 10
                 minH: 1
               - cx: 3
                 cy: 0
-                i: 'recentlyVisited#recentlyVisited'
+                i: 'landing-./RecentlyVisited#recentlyVisited'
                 w: 1
                 h: 3
                 maxH: 10
                 minH: 1
               - cx: 3
                 cy: 1
-                i: 'favoriteServices#favoriteServices'
+                i: 'chrome-./DashboardFavorites#favoriteServices'
                 w: 1
                 h: 5
                 maxH: 10
                 minH: 1
               - cx: 3
                 cy: 2
-                i: 'subscriptions#subscriptions'
+                i: 'subscriptionInventory-./SubscriptionsWidget#subscriptions'
                 w: 1
                 h: 6
                 maxH: 10
                 minH: 1
               - cx: 0
                 cy: 3
-                i: 'openshiftAi#openshiftAi'
+                i: 'landing-./OpenShiftAiWidget#openshiftAi'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 1
                 cy: 3
-                i: 'imageBuilder#imageBuilder'
+                i: 'landing-./ImageBuilderWidget#imageBuilder'
                 w: 1
                 h: 4
                 maxH: 10
                 minH: 1
               - cx: 2
                 cy: 3
-                i: 'acs#acs'
+                i: 'landing-./AcsWidget#acs'
                 w: 1
                 h: 4
                 maxH: 10


### PR DESCRIPTION
## Summary

- **RHCLOUD-48967**: Widget dashboard returns empty layout for new users instead of default
- Base widget layout IDs in `frontend.yml` used old shorthand format (`rhel#rhel`, `openshift#openshift`, etc.) that doesn't match the widget mapping keys (`landing-./RhelWidget`, `landing-./OpenShiftWidget`, etc.)
- Frontend extracts widget type from the `i` field by splitting on `#`, then looks it up in the widget mapping — no match means no render
- Updated all 40 widget ID references across all 4 breakpoints (sm/md/lg/xl) to use the correct `{scope}-{module}#{id}` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)